### PR TITLE
feat(@flex/sdk): domain and route configuration PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ coverage/
 cdk.context.json
 
 .env
+
+# HTTP client
+*.http

--- a/domains/poc/README.md
+++ b/domains/poc/README.md
@@ -1,0 +1,163 @@
+# @flex/poc-domain
+
+TODO: Description
+
+---
+
+## Commands
+
+Run these from the repository root:
+
+| Command                               | Description    |
+| ------------------------------------- | -------------- |
+| `pnpm --filter @flex/poc-domain lint` | Lint files     |
+| `pnpm --filter @flex/poc-domain test` | Run tests      |
+| `pnpm --filter @flex/poc-domain tsc`  | Run type check |
+
+Alternatively, run `pnpm <command>` from within `domains/poc/`.
+
+---
+
+## API
+
+### Handlers
+
+| Name                                   | Description       | Code                                           |
+| -------------------------------------- | ----------------- | ---------------------------------------------- |
+| [`GET /public`](#get-public)           | TODO: Description | [View](./src/handlers/v1/public/get.ts)        |
+| [`GET /private`](#get-private)         | TODO: Description | [View](./src/handlers/v1/private/get.ts)       |
+| [`GET /isolated`](#get-isolated)       | TODO: Description | [View](./src/handlers/v1/isolated/get.ts)      |
+| [`PATCH /isolated`](#patch-isolated)   | TODO: Description | [View](./src/handlers/v1/isolated/patch.ts)    |
+| [`GET /isolated/:id`](#get-isolatedid) | TODO: Description | [View](./src/handlers/v1/isolated/[id]/get.ts) |
+
+---
+
+## GET `/public`
+
+TODO: Description
+
+### Response
+
+```json
+{
+  "message": "Public GET",
+  "context": {
+    "logger": "<logger_instance>",
+    "queryParams": {
+      "page": 1,
+      "limit": 20,
+      "sort": "desc"
+    },
+    "resources": {
+      "encryptionKeyArn": "<arn>",
+      "flexUdpNotificationSecret": "<secret>"
+    }
+  }
+}
+```
+
+## GET `/private`
+
+TODO: Description
+
+### Response
+
+```json
+{
+  "message": "Private GET",
+  "context": {
+    "logger": "<logger_instance>",
+    "auth": {
+      "pairwiseId": "<id>"
+    },
+    "resources": {
+      "encryptionKeyArn": "<arn>",
+      "flexUdpNotificationSecret": "<secret>"
+    }
+  }
+}
+```
+
+## GET `/isolated`
+
+TODO: Description
+
+### Response
+
+```json
+{
+  "message": "Isolated GET",
+  "context": {
+    "logger": "<logger_instance>",
+    "auth": {
+      "pairwiseId": "<id>"
+    },
+    "resources": {
+      "encryptionKeyArn": "<arn>",
+      "flexUdpNotificationSecret": "<secret>"
+    }
+  }
+}
+```
+
+## PATCH `/isolated`
+
+TODO: Description
+
+### Response
+
+```json
+{
+  "message": "Isolated PATCH",
+  "context": {
+    "logger": "<logger_instance>",
+    "auth": {
+      "pairwiseId": "<id>"
+    },
+    "resources": {
+      "encryptionKeyArn": "<arn>",
+      "flexUdpNotificationSecret": "<secret>"
+    },
+    "body": {
+      "message": "<string>"
+    }
+  }
+}
+```
+
+## GET `/isolated/:id`
+
+TODO: Description
+
+### Response
+
+```json
+{
+  "message": "Isolated GET + path params",
+  "context": {
+    "logger": "<logger_instance>",
+    "auth": {
+      "pairwiseId": "<id>"
+    },
+    "resources": {
+      "encryptionKeyArn": "<arn>",
+      "flexUdpNotificationSecret": "<secret>"
+    },
+    "pathParams": {
+      "id": "<string>"
+    }
+  }
+}
+```
+
+---
+
+## Related
+
+**FLEX:**
+
+- [@flex/handlers](/libs/handlers/README.md)
+- [@flex/testing](/libs/testing/README.md)
+- [@platform/flex](/platform/infra/flex/README.md)
+- [@platform/flex: POC Domain](/platform/infra/flex/src/stack.ts)
+- [Domain Development Guide](/docs/domain-development.md)

--- a/domains/poc/domain.config.ts
+++ b/domains/poc/domain.config.ts
@@ -1,0 +1,84 @@
+import { domain, header, integration, resource } from "@flex/sdk";
+import {
+  createUserRequestSchema,
+  preferencesRequestSchema,
+  preferencesResponseSchema,
+  userProfileResponseSchema,
+} from "@flex/udp-domain";
+
+const { config, route, routeContext } = domain({
+  name: "poc",
+  common: {
+    function: { timeoutSeconds: 30 },
+  },
+  resources: {
+    encryptionKeyArn: resource.kms("/flex-secret/encryption-key"),
+    flexPrivateGatewayUrl: resource.ssm("/flex-core/private-gateway/url", {
+      scope: "stage",
+    }),
+    flexUdpNotificationSecret: resource.secret(
+      "/flex-secret/udp/notification-hash-secret",
+    ),
+  },
+  integrations: {
+    udpRead: integration.gateway("GET /v1/*", { target: "udp" }),
+    udpWrite: integration.gateway("POST /v1/*", { target: "udp" }),
+    udpPatchUser: integration.domain("PATCH /v1/user", {
+      target: "udp",
+      body: preferencesRequestSchema,
+      response: preferencesResponseSchema,
+    }),
+  },
+  routes: {
+    v1: {
+      "/poc-user": {
+        GET: {
+          public: {
+            name: "get-user-profile",
+            resources: [
+              "encryptionKeyArn",
+              "flexPrivateGatewayUrl",
+              "flexUdpNotificationSecret",
+            ],
+            integrations: ["udpRead", "udpWrite"],
+            response: userProfileResponseSchema,
+          },
+        },
+        POST: {
+          private: {
+            name: "create-user-profile",
+            resources: ["flexPrivateGatewayUrl"],
+            integrations: ["udpWrite"],
+            body: createUserRequestSchema,
+          },
+        },
+        PATCH: {
+          public: {
+            name: "update-user-preferences",
+            resources: ["flexPrivateGatewayUrl"],
+            integrations: ["udpPatchUser"],
+            body: preferencesRequestSchema,
+            response: preferencesResponseSchema,
+          },
+          private: {
+            name: "sync-user-preferences",
+            resources: ["flexPrivateGatewayUrl"],
+            integrations: ["udpWrite"],
+            headers: {
+              requestingServiceUserId: header("requesting-service-user-id"),
+            },
+            body: preferencesRequestSchema,
+          },
+        },
+      },
+    },
+  },
+});
+
+export const getUserContext = routeContext<"GET /v1/poc-user">;
+export const createUserContext = routeContext<"POST /v1/poc-user [private]">;
+export const patchUserContext = routeContext<"PATCH /v1/poc-user">;
+export const patchUserPrivateContext =
+  routeContext<"PATCH /v1/poc-user [private]">;
+
+export { config, route };

--- a/domains/poc/eslint.config.mjs
+++ b/domains/poc/eslint.config.mjs
@@ -1,0 +1,3 @@
+import { config } from "@flex/config/eslint";
+
+export default config;

--- a/domains/poc/package.json
+++ b/domains/poc/package.json
@@ -1,30 +1,18 @@
 {
-  "name": "@flex/udp-domain",
+  "name": "@flex/poc-domain",
   "version": "1.0.0",
   "type": "module",
   "private": true,
-  "exports": {
-    ".": "./src/index.ts"
-  },
   "scripts": {
     "tsc": "tsc --noEmit",
     "lint": "eslint --max-warnings=0 .",
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@aws-lambda-powertools/parser": "2.31.0",
-    "@aws-sdk/client-secrets-manager": "3.985.0",
-    "@flex/flex-fetch": "workspace:*",
     "@flex/handlers": "workspace:*",
-    "@flex/logging": "workspace:*",
-    "@flex/middlewares": "workspace:*",
-    "@flex/params": "workspace:*",
     "@flex/sdk": "workspace:*",
     "@flex/utils": "workspace:*",
-    "@middy/http-header-normalizer": "7.0.2",
-    "@middy/http-json-body-parser": "7.0.2",
-    "@middy/secrets-manager": "7.0.2",
-    "@smithy/util-utf8": "^4.2.0",
+    "@flex/udp-domain": "workspace:*",
     "http-errors": "2.0.1",
     "http-status": "2.1.0",
     "zod": "4.3.6"
@@ -32,13 +20,10 @@
   "devDependencies": {
     "@flex/config": "workspace:*",
     "@flex/testing": "workspace:*",
-    "@middy/core": "7.0.2",
     "@types/aws-lambda": "8.10.160",
     "@types/http-errors": "2.0.5",
-    "@types/ramda": "0.31.1",
     "eslint": "9.39.2",
     "nock": "14.0.11",
-    "ramda": "0.32.0",
     "typescript": "5.9.3",
     "vitest": "4.0.18"
   }

--- a/domains/poc/src/handlers/v1/poc-user/get.ts
+++ b/domains/poc/src/handlers/v1/poc-user/get.ts
@@ -1,0 +1,119 @@
+import crypto from "node:crypto";
+
+import type {
+  CreateUserRequest,
+  CreateUserResponse,
+  PreferencesRequest,
+  PreferencesResponse,
+} from "@flex/udp-domain";
+import createHttpError from "http-errors";
+
+import { getUserContext, route } from "../../../../domain.config";
+
+export const handler = route("GET /v1/poc-user", async ({ auth, logger }) => {
+  const notificationId = generateDerivedId();
+
+  let preferencesResult = await getUserPreferences();
+
+  if (!preferencesResult.ok) {
+    if (preferencesResult.error.status !== 404) {
+      logger.error("Failed to get user preferences", {
+        response: JSON.stringify(preferencesResult),
+        status: preferencesResult.error.status,
+        body: preferencesResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    logger.debug("User settings not found, creating user");
+
+    const createUserResult = await createUser(notificationId);
+
+    if (!createUserResult.ok) {
+      logger.error("Failed to create user", {
+        response: JSON.stringify(createUserResult),
+        status: createUserResult.error.status,
+        body: createUserResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    logger.debug("User created successfully, setting default preferences");
+
+    const defaultPreferencesResult = await updateUserPreferences();
+
+    if (!defaultPreferencesResult.ok) {
+      logger.error("Failed to set default preferences", {
+        response: JSON.stringify(defaultPreferencesResult),
+        status: defaultPreferencesResult.error.status,
+        body: defaultPreferencesResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    preferencesResult = await getUserPreferences();
+
+    if (!preferencesResult.ok) {
+      logger.error("Failed to get user preferences after creating user", {
+        response: JSON.stringify(preferencesResult),
+        status: preferencesResult.error.status,
+        body: preferencesResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+  }
+
+  return {
+    status: 200,
+    data: {
+      appId: auth.pairwiseId,
+      notificationId,
+      preferences: preferencesResult.data.preferences,
+    },
+  };
+});
+
+// ----------------------------------------------------------------------------
+// Example: Accessing context outside of route handler via routeContext helpers
+// ----------------------------------------------------------------------------
+
+function generateDerivedId() {
+  const { auth, resources } = getUserContext();
+
+  return crypto
+    .createHmac("sha256", resources.flexUdpNotificationSecret)
+    .update(auth.pairwiseId)
+    .digest("base64url");
+}
+
+async function getUserPreferences() {
+  const { auth, integrations } = getUserContext();
+
+  return await integrations.udpRead<PreferencesResponse>({
+    path: "/notifications",
+    headers: { "requesting-service-user-id": auth.pairwiseId },
+  });
+}
+
+async function updateUserPreferences() {
+  const { auth, integrations } = getUserContext();
+
+  return await integrations.udpWrite<PreferencesRequest, PreferencesResponse>({
+    path: "/notifications",
+    headers: { "requesting-service-user-id": auth.pairwiseId },
+    body: { preferences: { notifications: { consentStatus: "unknown" } } },
+  });
+}
+
+async function createUser(notificationId: string) {
+  const { auth, integrations } = getUserContext();
+
+  return await integrations.udpWrite<CreateUserRequest, CreateUserResponse>({
+    path: "/user",
+    body: { appId: auth.pairwiseId, notificationId },
+  });
+}

--- a/domains/poc/src/handlers/v1/poc-user/patch.private.ts
+++ b/domains/poc/src/handlers/v1/poc-user/patch.private.ts
@@ -1,0 +1,35 @@
+import type { PreferencesRequest, PreferencesResponse } from "@flex/udp-domain";
+import createHttpError from "http-errors";
+
+import { route } from "../../../../domain.config";
+
+export const handler = route(
+  "PATCH /v1/poc-user [private]",
+  async ({ body, headers, integrations, logger }) => {
+    const updatePreferencesResult = await integrations.udpWrite<
+      PreferencesRequest,
+      PreferencesResponse
+    >({
+      path: "/notifications",
+      headers: {
+        "requesting-service-user-id": headers.requestingServiceUserId,
+      },
+      body,
+    });
+
+    if (!updatePreferencesResult.ok) {
+      logger.error("Failed to update user preferences", {
+        response: JSON.stringify(updatePreferencesResult),
+        status: updatePreferencesResult.error.status,
+        body: updatePreferencesResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    return {
+      status: 200,
+      data: updatePreferencesResult.data,
+    };
+  },
+);

--- a/domains/poc/src/handlers/v1/poc-user/patch.ts
+++ b/domains/poc/src/handlers/v1/poc-user/patch.ts
@@ -1,0 +1,28 @@
+import createHttpError from "http-errors";
+
+import { route } from "../../../../domain.config";
+
+export const handler = route(
+  "PATCH /v1/poc-user",
+  async ({ auth, body, integrations, logger }) => {
+    const patchUserResult = await integrations.udpPatchUser({
+      body,
+      headers: { "requesting-service-user-id": auth.pairwiseId },
+    });
+
+    if (!patchUserResult.ok) {
+      logger.error("Failed to update user preferences", {
+        response: JSON.stringify(patchUserResult),
+        status: patchUserResult.error.status,
+        body: patchUserResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    return {
+      status: 200,
+      data: patchUserResult.data,
+    };
+  },
+);

--- a/domains/poc/src/handlers/v1/poc-user/post.private.ts
+++ b/domains/poc/src/handlers/v1/poc-user/post.private.ts
@@ -1,0 +1,31 @@
+import type { CreateUserRequest, CreateUserResponse } from "@flex/udp-domain";
+import createHttpError from "http-errors";
+
+import { route } from "../../../../domain.config";
+
+export const handler = route(
+  "POST /v1/poc-user [private]",
+  async ({ body, integrations, logger }) => {
+    const createUserResult = await integrations.udpWrite<
+      CreateUserRequest,
+      CreateUserResponse
+    >({
+      path: "/user",
+      body,
+    });
+
+    if (!createUserResult.ok) {
+      logger.error("Failed to create user", {
+        response: JSON.stringify(createUserResult),
+        status: createUserResult.error.status,
+        body: createUserResult.error.body,
+      });
+
+      throw new createHttpError.BadGateway();
+    }
+
+    return {
+      status: 204,
+    };
+  },
+);

--- a/domains/poc/tsconfig.json
+++ b/domains/poc/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@flex/config/tsconfig.json",
+  "include": ["src/**/*.ts", "vitest.config.ts", "domain.config.ts"]
+}

--- a/domains/poc/vitest.config.ts
+++ b/domains/poc/vitest.config.ts
@@ -1,0 +1,3 @@
+import { config } from "@flex/config/vitest";
+
+export default config;

--- a/domains/udp/src/index.ts
+++ b/domains/udp/src/index.ts
@@ -1,0 +1,14 @@
+export type {
+  PreferencesRequest,
+  PreferencesResponse,
+} from "./schemas/preferences";
+export {
+  preferencesRequestSchema,
+  preferencesResponseSchema,
+} from "./schemas/preferences";
+export type { CreateUserRequest, CreateUserResponse } from "./schemas/user";
+export {
+  createUserRequestSchema,
+  createUserResponseSchema,
+  userProfileResponseSchema,
+} from "./schemas/user";

--- a/domains/udp/src/schemas/user.ts
+++ b/domains/udp/src/schemas/user.ts
@@ -13,3 +13,15 @@ export const createUserResponseSchema = z.object({
 });
 
 export type CreateUserResponse = z.infer<typeof createUserResponseSchema>;
+
+export const userProfileResponseSchema = z.object({
+  notificationId: NonEmptyString,
+  appId: NonEmptyString,
+  preferences: z.object({
+    notifications: z.object({
+      consentStatus: z.enum(["unknown", "accepted", "denied"]),
+    }),
+  }),
+});
+
+export type UserProfileResponse = z.infer<typeof userProfileResponseSchema>;

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -12,12 +12,25 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.237.1",
+    "@flex/logging": "workspace:*",
+    "@flex/flex-fetch": "workspace:*",
+    "@flex/utils": "workspace:*",
+    "@middy/core": "7.0.2",
+    "@middy/http-error-handler": "7.0.2",
+    "@middy/http-header-normalizer": "7.0.2",
+    "@middy/http-json-body-parser": "7.0.2",
+    "@middy/secrets-manager": "7.0.2",
+    "@middy/ssm": "7.0.2",
     "zod": "4.3.6"
   },
   "devDependencies": {
+    "@aws-sdk/client-ssm": "3.990.0",
     "@flex/config": "workspace:*",
+    "@flex/testing": "workspace:*",
+    "@types/aws-lambda": "8.10.160",
+    "@types/http-errors": "2.0.5",
     "eslint": "9.39.2",
+    "http-errors": "2.0.1",
     "typescript": "5.9.3",
     "vitest": "4.0.18"
   }

--- a/libs/sdk/src/config/header.ts
+++ b/libs/sdk/src/config/header.ts
@@ -1,0 +1,6 @@
+export function header<const Required extends boolean = true>(
+  name: string,
+  options?: { required: Required },
+) {
+  return { name, required: (options?.required ?? true) as Required };
+}

--- a/libs/sdk/src/config/index.ts
+++ b/libs/sdk/src/config/index.ts
@@ -1,0 +1,5 @@
+export { header } from "./header";
+export { integration } from "./integration";
+export { resource } from "./resource";
+export type { IacDomainConfig } from "./schema";
+export { DomainConfigSchema } from "./schema";

--- a/libs/sdk/src/config/integration.ts
+++ b/libs/sdk/src/config/integration.ts
@@ -1,0 +1,34 @@
+import type { ZodType } from "zod";
+
+import type {
+  InferDomainIntegrationOptions,
+  IntegrationDomainService,
+  IntegrationServiceGateway,
+} from "../types";
+
+export const integration = {
+  domain: <
+    Route extends string,
+    Body extends ZodType = ZodType,
+    Response extends ZodType = ZodType,
+  >(
+    route: Route,
+    options?: InferDomainIntegrationOptions<Route, Body, Response>,
+  ): IntegrationDomainService<Route, Body, Response> => ({
+    type: "domain",
+    route,
+    ...options,
+  }),
+  gateway: <
+    Route extends string,
+    Body extends ZodType = ZodType,
+    Response extends ZodType = ZodType,
+  >(
+    route: Route,
+    options?: InferDomainIntegrationOptions<Route, Body, Response>,
+  ): IntegrationServiceGateway<Route, Body, Response> => ({
+    type: "gateway",
+    route,
+    ...options,
+  }),
+} as const;

--- a/libs/sdk/src/config/resource.ts
+++ b/libs/sdk/src/config/resource.ts
@@ -1,0 +1,21 @@
+import type {
+  DomainResource,
+  SecretResourceOptions,
+  SsmResourceOptions,
+} from "../types";
+
+export const resource = {
+  secret: (
+    path: string,
+    { scope = "environment" }: SecretResourceOptions = {},
+  ): DomainResource<"secret"> => ({ type: "secret", path, scope }),
+  ssm: (
+    path: string,
+    { scope = "environment", resolution = "deploy" }: SsmResourceOptions = {},
+  ): DomainResource<"ssm"> | DomainResource<"ssm:runtime"> => ({
+    type: resolution === "deploy" ? "ssm" : "ssm:runtime",
+    path,
+    scope,
+  }),
+  kms: (path: string): DomainResource<"kms"> => ({ type: "kms", path }),
+} as const;

--- a/libs/sdk/src/config/schema.ts
+++ b/libs/sdk/src/config/schema.ts
@@ -1,0 +1,110 @@
+import { NonEmptyString } from "@flex/utils";
+import type { ZodType } from "zod";
+import { z } from "zod";
+
+const RouteAccessSchema = z.enum(["public", "private", "isolated"]);
+
+const LogLevelSchema = z.enum([
+  "TRACE",
+  "DEBUG",
+  "INFO",
+  "WARN",
+  "ERROR",
+  "SILENT",
+  "CRITICAL",
+]);
+
+const HttpMethodSchema = z.enum([
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+]);
+
+const FunctionConfigSchema = z.object({
+  environment: z.record(NonEmptyString, NonEmptyString).optional(),
+  memorySize: z.number().int().min(128).max(10240).optional(),
+  timeoutSeconds: z.number().int().min(1).max(900).optional(),
+});
+
+const HeaderConfigSchema = z.object({
+  name: NonEmptyString,
+  required: z.boolean().optional(),
+});
+
+const DomainIntegrationBaseSchema = z.object({
+  route: NonEmptyString,
+  target: NonEmptyString.optional(),
+  body: z.custom<ZodType>().optional(),
+  response: z.custom<ZodType>().optional(),
+});
+
+const IntegrationDomainServiceSchema = DomainIntegrationBaseSchema.extend({
+  type: z.literal("domain"),
+});
+
+const IntegrationServiceGatewaySchema = DomainIntegrationBaseSchema.extend({
+  type: z.literal("gateway"),
+});
+
+const DomainIntegrationSchema = z.discriminatedUnion("type", [
+  IntegrationDomainServiceSchema,
+  IntegrationServiceGatewaySchema,
+]);
+
+const DomainConfigCommonSchema = z.object({
+  access: RouteAccessSchema.optional(),
+  logLevel: LogLevelSchema.optional(),
+  function: FunctionConfigSchema.optional(),
+  headers: z.record(NonEmptyString, HeaderConfigSchema).optional(),
+});
+
+const DomainResourceSchema = z.object({
+  type: z.enum(["secret", "ssm", "ssm:runtime", "kms"]),
+  path: NonEmptyString,
+  scope: z.enum(["environment", "stage"]).optional(),
+});
+
+const MethodRouteConfigSchema = z.object({
+  name: NonEmptyString,
+  access: RouteAccessSchema.optional(),
+  function: FunctionConfigSchema.optional(),
+  logLevel: LogLevelSchema.optional(),
+  body: z.custom<ZodType>().optional(),
+  query: z.custom<ZodType>().optional(),
+  response: z.custom<ZodType>().optional(),
+  resources: z.array(NonEmptyString).readonly().optional(),
+  integrations: z.array(NonEmptyString).readonly().optional(),
+  headers: z.record(NonEmptyString, HeaderConfigSchema).optional(),
+});
+
+const GatewayRouteConfigSchema = z
+  .object({
+    public: MethodRouteConfigSchema.optional(),
+    private: MethodRouteConfigSchema.optional(),
+  })
+  .refine(
+    (v) => v.public != null || v.private != null,
+    'At least one "public" or "private" route must be defined',
+  );
+
+const PathRoutesSchema = z.record(
+  HttpMethodSchema,
+  GatewayRouteConfigSchema.optional(),
+);
+
+const VersionRoutesSchema = z.record(NonEmptyString, PathRoutesSchema);
+
+export const DomainConfigSchema = z.object({
+  name: NonEmptyString,
+  routes: z.record(NonEmptyString, VersionRoutesSchema),
+  common: DomainConfigCommonSchema.optional(),
+  resources: z.record(NonEmptyString, DomainResourceSchema).optional(),
+  integrations: z.record(NonEmptyString, DomainIntegrationSchema).optional(),
+  owner: NonEmptyString.optional(),
+});
+
+export type IacDomainConfig = z.infer<typeof DomainConfigSchema>;

--- a/libs/sdk/src/domain.ts
+++ b/libs/sdk/src/domain.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+
+import { createRouteContext, createRouteHandler } from "./route";
+import type {
+  DomainConfig,
+  DomainResult,
+  HttpMethod,
+  InferIntegrationKeys,
+  InferResourceKeys,
+} from "./types";
+
+// ----------------------------------------------------------------------------
+// PoC Domain
+// ----------------------------------------------------------------------------
+
+export function domain<
+  const Config extends DomainConfig<
+    InferResourceKeys<Config>,
+    InferIntegrationKeys<Config>
+  >,
+>(config: Config): DomainResult<Config> {
+  return {
+    config,
+    route: createRouteHandler(config),
+    routeContext: createRouteContext(config),
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Hello/UDP Domains
+// ----------------------------------------------------------------------------
+
+const permissionsSchema = z.object({
+  type: z.enum(["domain", "gateway"]),
+  path: z.string(),
+  method: z.string(),
+  // TODO: intra-domain permissions
+});
+
+export type Permission = z.infer<typeof permissionsSchema>;
+
+const handlerConfigSchema = z.object({
+  entry: z.string(),
+  type: z.enum(["PUBLIC", "PRIVATE", "ISOLATED"]),
+  env: z.record(z.string(), z.string()).optional(),
+  envEphemeral: z.record(z.string(), z.string()).optional(),
+  envSecret: z.record(z.string(), z.string()).optional(),
+  kmsKeys: z.record(z.string(), z.string()).optional(),
+  permissions: z.array(permissionsSchema).optional(),
+  timeoutSeconds: z.number().optional(),
+});
+
+const routeMethodsSchema = z
+  .object(
+    Object.fromEntries(
+      ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"].map((m) => [
+        m,
+        handlerConfigSchema,
+      ]),
+    ),
+  )
+  .partial();
+
+const versionRouteSchema = z.record(
+  z.string().startsWith("/"),
+  routeMethodsSchema,
+);
+
+export const domainSchema = z.object({
+  domain: z.string(),
+  owner: z.string().optional(),
+  versions: z.record(z.string(), z.object({ routes: versionRouteSchema })),
+});
+
+type InferredDomain = z.infer<typeof domainSchema>;
+export type IDomainEndpoint = z.infer<typeof handlerConfigSchema>;
+
+export type IDomain = Omit<InferredDomain, "versions"> & {
+  versions: Record<
+    string,
+    {
+      routes: Record<string, Partial<Record<HttpMethod, IDomainEndpoint>>>;
+    }
+  >;
+};
+
+export function defineDomain<const T extends IDomain>(config: T) {
+  domainSchema.parse(config);
+  return config;
+}

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -1,58 +1,27 @@
-import { HttpMethod } from "aws-cdk-lib/aws-apigatewayv2";
-import { z } from "zod";
-
-const permissionsSchema = z.object({
-  type: z.enum(["domain", "gateway"]),
-  path: z.string(),
-  method: z.string(),
-  // TODO: intra-domain permissions
-});
-
-export type Permission = z.infer<typeof permissionsSchema>;
-
-const handlerConfigSchema = z.object({
-  entry: z.string(),
-  type: z.enum(["PUBLIC", "PRIVATE", "ISOLATED"]),
-  env: z.record(z.string(), z.string()).optional(),
-  envEphemeral: z.record(z.string(), z.string()).optional(),
-  envSecret: z.record(z.string(), z.string()).optional(),
-  kmsKeys: z.record(z.string(), z.string()).optional(),
-  permissions: z.array(permissionsSchema).optional(),
-  timeoutSeconds: z.number().optional(),
-});
-
-const routeMethodsSchema = z
-  .object(
-    Object.fromEntries(
-      Object.values(HttpMethod).map((m) => [m, handlerConfigSchema]),
-    ) as Record<HttpMethod, typeof handlerConfigSchema>,
-  )
-  .partial();
-
-const versionRouteSchema = z.record(
-  z.string().startsWith("/"),
-  routeMethodsSchema,
-);
-
-export const domainSchema = z.object({
-  domain: z.string(),
-  owner: z.string().optional(),
-  versions: z.record(z.string(), z.object({ routes: versionRouteSchema })),
-});
-
-type InferredDomain = z.infer<typeof domainSchema>;
-export type IDomainEndpoint = z.infer<typeof handlerConfigSchema>;
-
-export type IDomain = Omit<InferredDomain, "versions"> & {
-  versions: Record<
-    string,
-    {
-      routes: Record<string, Partial<Record<HttpMethod, IDomainEndpoint>>>;
-    }
-  >;
-};
-
-export function defineDomain<const T extends IDomain>(config: T) {
-  domainSchema.parse(config);
-  return config;
-}
+export * from "./config";
+export type { IDomain, IDomainEndpoint, Permission } from "./domain";
+export { defineDomain, domain, domainSchema } from "./domain";
+export * from "./route";
+export type {
+  DomainConfig,
+  DomainIntegration,
+  DomainIntegrationOptions,
+  DomainResource,
+  DomainResult,
+  DomainRoutes,
+  FlexLambdaHandler,
+  FunctionConfig,
+  HandlerResult,
+  HeaderConfig,
+  HttpMethod,
+  InferDomainIntegrationOptions,
+  InferRouteContext,
+  IntegrationDomainService,
+  IntegrationResult,
+  IntegrationServiceGateway,
+  LambdaAuthorizerContext,
+  LogLevel,
+  RouteAccess,
+  RouteAuth,
+  RouteHandler,
+} from "./types";

--- a/libs/sdk/src/route/build-context.ts
+++ b/libs/sdk/src/route/build-context.ts
@@ -1,0 +1,117 @@
+import type { Logger } from "@flex/logging";
+import type { ZodType } from "zod";
+
+import type {
+  DomainIntegrations,
+  HeaderConfig,
+  LambdaContext,
+  LambdaEvent,
+  RouteAccess,
+  RouteAuth,
+} from "../types";
+import { RequestBodyParseError } from "../utils/errors";
+import { resolveHeaders } from "./headers";
+import type { ResolvedResource } from "./resolve-config";
+import type { RouteStore } from "./store";
+
+interface BuildContextOptions {
+  access: RouteAccess;
+  logger: Logger;
+  bodySchema?: ZodType;
+  querySchema?: ZodType;
+  resources?: ReadonlyMap<string, ResolvedResource>;
+  headers?: Readonly<Record<string, HeaderConfig>>;
+  integrations?: DomainIntegrations;
+}
+
+export function buildHandlerContext(
+  event: LambdaEvent,
+  context: LambdaContext,
+  {
+    access,
+    logger,
+    bodySchema,
+    querySchema,
+    resources,
+    headers,
+    integrations,
+  }: BuildContextOptions,
+): RouteStore {
+  const pathParams = extractPathParams(event);
+  const body = extractRequestBody(event.body, bodySchema);
+  const queryParams = extractQueryParams(event, querySchema);
+
+  return {
+    logger,
+    ...(access !== "public" && { auth: extractAuth(event) }),
+    ...(body !== undefined && { body }),
+    ...(pathParams && { pathParams }),
+    ...(queryParams && { queryParams }),
+    ...(resources && { resources: extractResources(context, resources) }),
+    ...(headers && { headers: resolveHeaders(headers, event.headers) }),
+    ...(integrations && { integrations }),
+  };
+}
+
+function extractAuth(event: LambdaEvent): RouteAuth {
+  const { pairwiseId } = event.requestContext.authorizer;
+
+  if (!pairwiseId) throw new Error("Pairwise ID not found");
+
+  return {
+    pairwiseId,
+  };
+}
+
+function extractPathParams(
+  event: LambdaEvent,
+): Readonly<Record<string, string>> | undefined {
+  if (!event.pathParameters) return;
+
+  return Object.fromEntries(
+    Object.entries(event.pathParameters).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  );
+}
+
+function extractQueryParams(event: LambdaEvent, schema?: ZodType) {
+  if (!schema) return;
+
+  return schema.parse(event.queryStringParameters ?? {}) as Readonly<
+    Record<string, unknown>
+  >;
+}
+
+function extractRequestBody(body: LambdaEvent["body"], schema?: ZodType) {
+  if (!schema) return;
+
+  try {
+    return schema.parse(typeof body === "string" ? JSON.parse(body) : body);
+  } catch {
+    throw new RequestBodyParseError("Invalid request body");
+  }
+}
+
+function extractResources(
+  context: LambdaContext,
+  resources: ReadonlyMap<string, ResolvedResource>,
+) {
+  if (resources.size === 0) return;
+
+  return Object.fromEntries(
+    Array.from(resources).map(([key, { type, value }]) => {
+      if (type === "kms" || type === "ssm") return [key, value];
+
+      const contextValue = (context as unknown as Record<string, unknown>)[key];
+
+      if (typeof contextValue !== "string") {
+        throw new Error(
+          `"${key}" (${type}) resource was not resolved by middleware`,
+        );
+      }
+
+      return [key, contextValue];
+    }),
+  );
+}

--- a/libs/sdk/src/route/create-route.ts
+++ b/libs/sdk/src/route/create-route.ts
@@ -1,0 +1,150 @@
+import { getLogger } from "@flex/logging";
+
+import type {
+  DomainConfig,
+  DomainResult,
+  InferRouteContext,
+  LambdaContext,
+  LambdaEvent,
+  LambdaResult,
+  RouteHandler,
+} from "../types";
+import { cache } from "../utils/cache";
+import { HeaderValidationError, RequestBodyParseError } from "../utils/errors";
+import { buildHandlerContext } from "./build-context";
+import { mergeHeaders } from "./headers";
+import { buildDomainIntegrations } from "./integrations";
+import { configureMiddleware } from "./middleware";
+import {
+  getRouteAccess,
+  getRouteConfig,
+  getRouteIntegrations,
+  getRouteLogLevel,
+  getRouteResources,
+} from "./resolve-config";
+import { toApiGatewayResponse, validateHandlerResponse } from "./response";
+import { extractRouteKeySegments } from "./route-key";
+import { getRouteStore, routeStorage } from "./store";
+
+export function createRouteHandler<const Config extends DomainConfig>(
+  config: Config,
+): RouteHandler<Config> {
+  const cachedBuildDomainIntegrations = cache(() =>
+    buildDomainIntegrations(config),
+  );
+
+  return (routeKey, handler) => {
+    const routeKeySegments = extractRouteKeySegments(routeKey);
+
+    const routeConfig = getRouteConfig(config, routeKeySegments);
+    const access = getRouteAccess(config.common?.access, routeConfig.access);
+    const logLevel = getRouteLogLevel(
+      config.common?.logLevel,
+      routeConfig.logLevel,
+    );
+    const resources = getRouteResources(
+      config.resources,
+      routeConfig.resources,
+    );
+    const headers = mergeHeaders(config.common?.headers, routeConfig.headers);
+
+    const { gateway, method, version } = routeKeySegments;
+
+    const verboseLogs = logLevel === "DEBUG" || logLevel === "TRACE";
+    const hasRequestBody =
+      method === "POST" || method === "PUT" || method === "PATCH";
+
+    const bodySchema = hasRequestBody ? routeConfig.body : undefined;
+    const querySchema = routeConfig.query;
+    const responseSchema = routeConfig.response;
+
+    const logger = getLogger({
+      serviceName: `${config.name}-${gateway}-${version}-${routeConfig.name}`,
+      logLevel,
+    });
+
+    const middyHandler = configureMiddleware({
+      logger,
+      logLevel,
+      hasRequestBody,
+      resources,
+    });
+
+    const coreHandler = async (
+      event: LambdaEvent,
+      context: LambdaContext,
+    ): Promise<LambdaResult> => {
+      try {
+        const integrations = getRouteIntegrations(
+          cachedBuildDomainIntegrations(),
+          routeConfig.integrations,
+        );
+
+        const store = buildHandlerContext(event, context, {
+          access,
+          logger,
+          bodySchema,
+          querySchema,
+          resources,
+          headers,
+          integrations,
+        });
+
+        return await routeStorage.run(store, async () => {
+          const handlerResult = await handler(
+            store as InferRouteContext<Config, typeof routeKey>,
+          );
+
+          const { errors, result } = validateHandlerResponse(
+            handlerResult,
+            responseSchema,
+            { showErrors: verboseLogs },
+          );
+
+          if (errors) {
+            logger.error("Response validation failed", {
+              errors,
+              ...(verboseLogs && { handlerResult }),
+            });
+          }
+
+          return toApiGatewayResponse(result);
+        });
+      } catch (error) {
+        if (error instanceof HeaderValidationError) {
+          const { headers, message, statusCode } = error;
+
+          logger.warn("Missing required headers", { headers });
+
+          return {
+            statusCode,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message, headers }),
+          };
+        }
+
+        if (error instanceof RequestBodyParseError) {
+          const { message, statusCode } = error;
+
+          logger.warn("Invalid request body", { message });
+
+          return {
+            statusCode,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message }),
+          };
+        }
+
+        throw error;
+      }
+    };
+
+    return middyHandler.handler(coreHandler);
+  };
+}
+
+export function createRouteContext<const Config extends DomainConfig>(
+  _: Config,
+): DomainResult<Config>["routeContext"] {
+  return (() => getRouteStore()) as DomainResult<Config>["routeContext"];
+}

--- a/libs/sdk/src/route/headers.ts
+++ b/libs/sdk/src/route/headers.ts
@@ -1,0 +1,50 @@
+import type { HeaderConfig } from "../types";
+import { HeaderValidationError } from "../utils/errors";
+
+type RouteHeaders = Readonly<Record<string, HeaderConfig>>;
+type EventHeaders = Readonly<Record<string, string | undefined>>;
+
+function isRequiredHeader(required?: boolean, value?: string) {
+  return required !== false && !value;
+}
+
+function normaliseEventHeaders(headers: EventHeaders) {
+  return new Map(
+    Object.entries(headers)
+      .filter((entry): entry is [string, string] => entry[1] !== undefined)
+      .map(([k, v]) => [k.toLowerCase(), v]),
+  );
+}
+
+export function mergeHeaders(
+  common?: RouteHeaders,
+  route?: RouteHeaders,
+): RouteHeaders | undefined {
+  if (!common && !route) return;
+
+  const headers = { ...common, ...route };
+
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
+export function resolveHeaders(
+  routeHeaders: RouteHeaders,
+  eventHeaders: EventHeaders = {},
+) {
+  const normalisedEventHeaders = normaliseEventHeaders(eventHeaders);
+
+  const headers: Record<string, string | undefined> = {};
+  const missing: string[] = [];
+
+  for (const [key, { name, required }] of Object.entries(routeHeaders)) {
+    const value = normalisedEventHeaders.get(name.toLowerCase());
+
+    if (isRequiredHeader(required, value)) missing.push(name);
+
+    headers[key] = value;
+  }
+
+  if (missing.length > 0) throw new HeaderValidationError(missing);
+
+  return headers;
+}

--- a/libs/sdk/src/route/index.ts
+++ b/libs/sdk/src/route/index.ts
@@ -1,0 +1,25 @@
+export { buildHandlerContext } from "./build-context";
+export { createRouteContext, createRouteHandler } from "./create-route";
+export { mergeHeaders, resolveHeaders } from "./headers";
+export {
+  buildDomainIntegrations,
+  createIntegrationInvoker,
+  parseIntegrationRoute,
+  toIntegrationResult,
+} from "./integrations";
+export { configureMiddleware } from "./middleware";
+export type { ResolvedResource } from "./resolve-config";
+export {
+  getRouteAccess,
+  getRouteConfig,
+  getRouteIntegrations,
+  getRouteLogLevel,
+  getRouteResources,
+} from "./resolve-config";
+export { toApiGatewayResponse, validateHandlerResponse } from "./response";
+export {
+  extractRouteKeySegments,
+  stripRouteKeyGatewayIdentifier,
+} from "./route-key";
+export type { RouteStore } from "./store";
+export { getRouteStore, routeStorage } from "./store";

--- a/libs/sdk/src/route/integrations.ts
+++ b/libs/sdk/src/route/integrations.ts
@@ -1,0 +1,223 @@
+import type { ApiResult, FlexFetchRequestInit } from "@flex/flex-fetch";
+import { createSigv4Fetcher, typedFetch } from "@flex/flex-fetch";
+import { type ZodType } from "zod";
+
+import type {
+  DomainConfig,
+  DomainIntegrations,
+  HttpMethod,
+  IntegrationResult,
+} from "../types";
+import { extractRouteKeySegments } from "./route-key";
+
+interface ParsedIntegrationRoute extends ReturnType<
+  typeof extractRouteKeySegments
+> {
+  readonly isWildcard: boolean;
+}
+
+export function parseIntegrationRoute(
+  routeKey: string,
+): ParsedIntegrationRoute {
+  const isWildcard = routeKey.endsWith("/*");
+
+  return {
+    ...extractRouteKeySegments(
+      isWildcard ? routeKey.replace(/\/\*$/, "") : routeKey,
+    ),
+    isWildcard,
+  };
+}
+
+// TODO: Is this needed? Identical shapes for now but will keep it incase either shape changes
+export function toIntegrationResult<T>(
+  result: ApiResult<T>,
+): IntegrationResult<T> {
+  if (result.ok) return { ok: true, status: result.status, data: result.data };
+
+  const { message, status, body } = result.error;
+
+  return { ok: false, error: { status, message, body } };
+}
+
+// ----------------------------------------------------------------------------
+// Integration / Request
+// ----------------------------------------------------------------------------
+
+interface InvokerOptions extends Pick<
+  FlexFetchRequestInit,
+  "maxRetryDelay" | "retryAttempts"
+> {
+  path?: string;
+  body?: unknown;
+  headers?: Readonly<Record<string, string>>;
+  query?: Readonly<Record<string, string>>;
+}
+
+interface IntegrationInvokerConfig extends Pick<
+  FlexFetchRequestInit,
+  "maxRetryDelay" | "retryAttempts"
+> {
+  readonly method: HttpMethod;
+  readonly basePath: string;
+  readonly path: string;
+  readonly isWildcard: boolean;
+  readonly schema?: ZodType;
+}
+
+function buildFetcherUrl(
+  {
+    basePath,
+    isWildcard,
+    path,
+  }: Pick<IntegrationInvokerConfig, "basePath" | "isWildcard" | "path">,
+  options?: InvokerOptions,
+) {
+  const pathname = `${basePath}${isWildcard ? (options?.path ?? "") : path}`;
+
+  if (!options?.query || Object.keys(options.query).length === 0) {
+    return pathname;
+  }
+
+  return `${pathname}?${new URLSearchParams(options.query)}`;
+}
+
+function buildFetcherOptions(
+  method: HttpMethod,
+  integration: Pick<
+    IntegrationInvokerConfig,
+    "maxRetryDelay" | "retryAttempts"
+  >,
+  invokerOptions?: InvokerOptions,
+): FlexFetchRequestInit {
+  const headers = { ...invokerOptions?.headers };
+
+  const hasBody = invokerOptions?.body !== undefined;
+
+  if (hasBody) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  return {
+    method,
+    retryAttempts: invokerOptions?.retryAttempts ?? integration.retryAttempts,
+    maxRetryDelay: invokerOptions?.maxRetryDelay ?? integration.maxRetryDelay,
+    ...(Object.keys(headers).length > 0 && { headers }),
+    ...(hasBody && { body: JSON.stringify(invokerOptions.body) }),
+  };
+}
+
+type SigV4Fetcher = (
+  path: string,
+  options?: FlexFetchRequestInit,
+) => { request: Promise<Response>; abort: () => void };
+
+export function createIntegrationInvoker(
+  fetcher: SigV4Fetcher,
+  integration: IntegrationInvokerConfig,
+): (...args: never[]) => Promise<IntegrationResult> {
+  return async (options?: InvokerOptions): Promise<IntegrationResult> => {
+    const { request } = fetcher(
+      buildFetcherUrl(integration, options),
+      buildFetcherOptions(integration.method, integration, options),
+    );
+
+    const resultPromise = await typedFetch(request, integration.schema);
+
+    return toIntegrationResult(resultPromise);
+  };
+}
+
+interface IntegrationBasePathConfig {
+  target: string;
+  type: "domain" | "gateway";
+  version: string;
+}
+
+function createIntegrationBasePath({
+  target,
+  type,
+  version,
+}: IntegrationBasePathConfig) {
+  return `/${type === "domain" ? "domains" : "gateways"}/${target}/${version}`;
+}
+
+function resolveGatewayUrl(
+  resources: DomainConfig["resources"],
+  gatewayPath: string,
+) {
+  if (!resources) {
+    throw new Error(
+      "Domain resources must define a gateway URL when integrations are used",
+    );
+  }
+
+  const entry = Object.entries(resources).find(
+    ([, { path }]) => path === gatewayPath,
+  );
+
+  if (!entry) {
+    throw new Error(`"${gatewayPath}" resource was not found`);
+  }
+
+  const [key] = entry;
+  const value = process.env[key];
+
+  if (!value) {
+    throw new Error(
+      `Environment variable "${key}" for gateway URL does not exist`,
+    );
+  }
+
+  return value;
+}
+
+// ----------------------------------------------------------------------------
+// Integration / Builder
+// ----------------------------------------------------------------------------
+
+export function buildDomainIntegrations(
+  config: DomainConfig,
+): DomainIntegrations | undefined {
+  if (!config.integrations || Object.keys(config.integrations).length === 0) {
+    return;
+  }
+
+  const region = process.env.AWS_REGION;
+
+  if (!region) {
+    throw new Error("AWS region is required when an integration is defined");
+  }
+
+  const fetcher = createSigv4Fetcher({
+    baseUrl: resolveGatewayUrl(
+      config.resources,
+      "/flex-core/private-gateway/url",
+    ),
+    region,
+  });
+
+  return Object.fromEntries(
+    Object.entries(config.integrations).map(([key, integration]) => {
+      const route = parseIntegrationRoute(integration.route);
+      const basePath = createIntegrationBasePath({
+        target: integration.target ?? config.name,
+        type: integration.type,
+        version: route.version,
+      });
+
+      return [
+        key,
+        createIntegrationInvoker(fetcher, {
+          method: route.method,
+          basePath,
+          path: route.path,
+          isWildcard: route.isWildcard,
+          schema: integration.response,
+          retryAttempts: integration.retryAttempts,
+          maxRetryDelay: integration.maxRetryDelay,
+        }),
+      ];
+    }),
+  );
+}

--- a/libs/sdk/src/route/middleware.ts
+++ b/libs/sdk/src/route/middleware.ts
@@ -1,0 +1,80 @@
+import type { Logger } from "@flex/logging";
+import { injectLambdaContext } from "@flex/logging";
+import middy from "@middy/core";
+import httpErrorHandler from "@middy/http-error-handler";
+import httpHeaderNormalizer from "@middy/http-header-normalizer";
+import httpJsonBodyParser from "@middy/http-json-body-parser";
+import secretsManagerMiddleware, { secret } from "@middy/secrets-manager";
+import ssmMiddleware from "@middy/ssm";
+
+import type { LambdaEvent, LambdaResult } from "../types";
+import type { ResolvedResource } from "./resolve-config";
+
+interface MiddlewareOptions {
+  readonly logger: Logger;
+  readonly logLevel: string;
+  readonly hasRequestBody: boolean;
+  readonly resources?: ReadonlyMap<string, ResolvedResource>;
+}
+
+export function configureMiddleware({
+  logger,
+  logLevel,
+  hasRequestBody,
+  resources,
+}: MiddlewareOptions) {
+  const middyHandler = middy<LambdaEvent, LambdaResult>()
+    .use(
+      httpErrorHandler({
+        logger: (error: Error) => {
+          logger.error("Unhandled error", { error });
+        },
+      }),
+    )
+    .use(
+      injectLambdaContext(logger, {
+        logEvent: logLevel === "DEBUG" || logLevel === "TRACE",
+        correlationIdPath: "requestContext.requestId",
+      }),
+    );
+
+  if (hasRequestBody) {
+    middyHandler
+      .use(httpHeaderNormalizer())
+      .use(httpJsonBodyParser<LambdaEvent>());
+  }
+
+  if (resources && resources.size > 0) {
+    const secrets = Array.from(resources).filter(
+      ([_, { type }]) => type === "secret",
+    );
+
+    if (secrets.length > 0) {
+      middyHandler.use(
+        secretsManagerMiddleware({
+          fetchData: Object.fromEntries(
+            secrets.map(([key, { value }]) => [key, secret(value)]),
+          ),
+          setToContext: true,
+        }),
+      );
+    }
+
+    const params = Array.from(resources).filter(
+      ([_, { type }]) => type === "ssm:runtime",
+    );
+
+    if (params.length > 0) {
+      middyHandler.use(
+        ssmMiddleware({
+          fetchData: Object.fromEntries(
+            params.map(([key, { value }]) => [key, value]),
+          ),
+          setToContext: true,
+        }),
+      );
+    }
+  }
+
+  return middyHandler;
+}

--- a/libs/sdk/src/route/resolve-config.ts
+++ b/libs/sdk/src/route/resolve-config.ts
@@ -1,0 +1,114 @@
+import type { ZodType } from "zod";
+
+import type {
+  DomainConfig,
+  DomainIntegrations,
+  DomainResource,
+  HeaderConfig,
+  HttpMethod,
+  LogLevel,
+  RouteAccess,
+} from "../types";
+
+interface RouteConfigOptions {
+  readonly version: string;
+  readonly path: string;
+  readonly method: HttpMethod;
+  readonly gateway: "public" | "private";
+}
+
+interface ResolvedRouteConfig {
+  readonly name: string;
+  readonly access?: RouteAccess;
+  readonly logLevel?: LogLevel;
+  readonly query?: ZodType;
+  readonly body?: ZodType;
+  readonly response?: ZodType;
+  readonly resources?: readonly string[];
+  readonly integrations?: readonly string[];
+  readonly headers?: Readonly<Record<string, HeaderConfig>>;
+}
+
+export function getRouteConfig(
+  config: DomainConfig,
+  { version, path, method, gateway }: RouteConfigOptions,
+): ResolvedRouteConfig {
+  const routeConfig = config.routes[version]?.[path]?.[method]?.[gateway];
+
+  if (!routeConfig) {
+    throw new Error(
+      `Route config for "${method} /${version}${path}${gateway === "private" ? " [private]" : ""}" does not exist`,
+    );
+  }
+
+  return routeConfig;
+}
+
+export interface ResolvedResource {
+  type: DomainResource["type"];
+  value: string;
+}
+
+/**
+ * Resolves resource values from their source
+ *
+ * - `kms`, `ssm`: Values are known at deploy time and injected as env vars, which are read directly from process.env.
+ * - `secret`, `ssm:runtime`: Values are fetched at runtime via Middy middleware and attached to the lambda context, so the env var refers to the resource name NOT the value
+ */
+export function getRouteResources(
+  resources: DomainConfig["resources"],
+  resourceKeys?: readonly string[],
+): ReadonlyMap<string, ResolvedResource> | undefined {
+  if (!resourceKeys?.length || !resources) return;
+
+  return new Map(
+    resourceKeys.map((key) => {
+      const resource = resources[key];
+
+      if (!resource) {
+        throw new Error(
+          `"${key}" referenced in "resources" but was not defined in domain resources`,
+        );
+      }
+
+      const value = process.env[key];
+
+      if (!value) {
+        throw new Error(
+          `Environment variable "${key}" not set. Has this resource been provisioned?`,
+        );
+      }
+
+      return [key, { type: resource.type, value }] as const;
+    }),
+  );
+}
+
+export function getRouteIntegrations(
+  integrations?: DomainIntegrations,
+  keys?: readonly string[],
+): DomainIntegrations | undefined {
+  if (!integrations || !keys?.length) return;
+
+  return Object.fromEntries(
+    keys.map((key) => {
+      const integration = integrations[key];
+
+      if (!integration) {
+        throw new Error(
+          `"${key}" referenced in "integrations" but the domain integration has not been defined`,
+        );
+      }
+
+      return [key, integration];
+    }),
+  );
+}
+
+export function getRouteAccess(common?: RouteAccess, route?: RouteAccess) {
+  return route ?? common ?? "isolated";
+}
+
+export function getRouteLogLevel(common?: LogLevel, route?: LogLevel) {
+  return route ?? common ?? "INFO";
+}

--- a/libs/sdk/src/route/response.ts
+++ b/libs/sdk/src/route/response.ts
@@ -1,0 +1,70 @@
+import type { ZodType } from "zod";
+
+import type { HandlerResult, LambdaResult } from "../types";
+
+export function toApiGatewayResponse(result: HandlerResult): LambdaResult {
+  const { status, ...response } = result;
+
+  if ("data" in response) {
+    const { data } = response;
+
+    return {
+      statusCode: status,
+      body: data != null ? JSON.stringify(data) : "",
+      headers: { "Content-Type": "application/json" },
+    };
+  }
+
+  if ("error" in response) {
+    const { error } = response;
+
+    return {
+      statusCode: status,
+      body: error != null ? JSON.stringify({ error }) : "",
+      headers: { "Content-Type": "application/json" },
+    };
+  }
+
+  return {
+    statusCode: status,
+    body: "",
+  };
+}
+
+interface ValidateHandlerResponseOptions {
+  showErrors?: boolean;
+}
+
+interface ValidationResult {
+  readonly result: HandlerResult;
+  readonly errors?: unknown[];
+}
+
+export function validateHandlerResponse(
+  result: HandlerResult,
+  schema?: ZodType,
+  options?: ValidateHandlerResponseOptions,
+): ValidationResult {
+  if (!schema || !("data" in result) || result.data === undefined) {
+    return { result };
+  }
+
+  const { success, error } = schema.safeParse(result.data);
+
+  if (!success) {
+    return {
+      result: {
+        status: 500,
+        error: options?.showErrors
+          ? {
+              message: "Failed handler response validation",
+              errors: error.issues,
+            }
+          : "Internal server error",
+      },
+      errors: error.issues,
+    };
+  }
+
+  return { result };
+}

--- a/libs/sdk/src/route/route-key.ts
+++ b/libs/sdk/src/route/route-key.ts
@@ -1,0 +1,31 @@
+import type { HttpMethod } from "../types";
+
+interface RouteKeySegments {
+  method: HttpMethod;
+  version: string;
+  path: string;
+  gateway: "public" | "private";
+}
+
+export function extractRouteKeySegments(routeKey: string) {
+  const [method, versionedPath] = routeKey.split(" ");
+
+  if (!method || !versionedPath) {
+    throw new Error(
+      `Invalid route key. Expected "METHOD /version/path" or "METHOD /version/path [private]", but got "${routeKey}"`,
+    );
+  }
+
+  const [, version, ...pathParts] = versionedPath.split("/");
+
+  return {
+    method,
+    version,
+    path: `/${pathParts.join("/")}`,
+    gateway: routeKey.endsWith("[private]") ? "private" : "public",
+  } as RouteKeySegments;
+}
+
+export function stripRouteKeyGatewayIdentifier(route: string) {
+  return route.replace(/\s+\[private\]$/, "");
+}

--- a/libs/sdk/src/route/store.ts
+++ b/libs/sdk/src/route/store.ts
@@ -1,0 +1,30 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { Logger } from "@flex/logging";
+
+import type { DomainIntegrations, RouteAuth } from "../types";
+
+export interface RouteStore {
+  readonly logger: Logger;
+  readonly auth?: Readonly<RouteAuth>;
+  readonly body?: unknown;
+  readonly pathParams?: Readonly<Record<string, string>>;
+  readonly queryParams?: Readonly<Record<string, unknown>>;
+  readonly resources?: Readonly<Record<string, string>>;
+  readonly headers?: Readonly<Record<string, string | undefined>>;
+  readonly integrations?: DomainIntegrations;
+}
+
+export const routeStorage = new AsyncLocalStorage<RouteStore>();
+
+export function getRouteStore(): RouteStore {
+  const store = routeStorage.getStore();
+
+  if (!store) {
+    throw new Error(
+      "Route store is not available. Must be called within a route handler",
+    );
+  }
+
+  return store;
+}

--- a/libs/sdk/src/types.ts
+++ b/libs/sdk/src/types.ts
@@ -1,0 +1,602 @@
+import type { FlexFetchRequestInit } from "@flex/flex-fetch";
+import type { Logger } from "@flex/logging";
+import type {
+  APIGatewayProxyEventBase,
+  APIGatewayProxyResult,
+  Context,
+} from "aws-lambda";
+import type { ZodType } from "zod";
+
+// ----------------------------------------------------------------------------
+// Flex Function
+// ----------------------------------------------------------------------------
+
+// Add more fields if needed, based on Nodejsfunction
+export interface FunctionConfig {
+  environment?: Readonly<Record<string, string>>;
+  memorySize?: number;
+  timeoutSeconds?: number;
+}
+
+// ----------------------------------------------------------------------------
+// Headers
+// ----------------------------------------------------------------------------
+
+export interface HeaderConfig {
+  readonly name: string;
+  readonly required?: boolean;
+}
+
+type MergeRouteHeaders<
+  Config extends DomainConfig,
+  RouteConfig,
+> = (Config extends {
+  readonly common: {
+    readonly headers: infer CommonHeaders extends Readonly<
+      Record<string, HeaderConfig>
+    >;
+  };
+}
+  ? CommonHeaders
+  : unknown) &
+  (RouteConfig extends {
+    readonly headers: infer RouteHeaders extends Readonly<
+      Record<string, HeaderConfig>
+    >;
+  }
+    ? RouteHeaders
+    : unknown);
+
+type ResolveHeaders<Headers> = keyof Headers extends never
+  ? unknown
+  : {
+      readonly headers: {
+        readonly [Key in keyof Headers]: Headers[Key] extends {
+          readonly required: false;
+        }
+          ? string | undefined
+          : string;
+      };
+    };
+
+// ----------------------------------------------------------------------------
+// Resources
+// ----------------------------------------------------------------------------
+
+export interface DomainResource<T extends string = string> {
+  readonly type: T;
+  readonly path: string;
+  readonly scope?: "environment" | "stage";
+}
+
+interface DomainResourceCommonOptions {
+  scope?: "environment" | "stage";
+}
+
+export type SecretResourceOptions = DomainResourceCommonOptions;
+
+export interface SsmResourceOptions extends DomainResourceCommonOptions {
+  resolution?: "deploy" | "runtime";
+}
+
+// ----------------------------------------------------------------------------
+// Integrations
+// ----------------------------------------------------------------------------
+
+export interface DomainIntegrationOptions<
+  Body extends ZodType = ZodType,
+  Response extends ZodType = ZodType,
+> extends Pick<FlexFetchRequestInit, "maxRetryDelay" | "retryAttempts"> {
+  readonly target?: string;
+  readonly body?: Body;
+  readonly response?: Response;
+}
+
+export type InferDomainIntegrationOptions<
+  Route extends string,
+  Body extends ZodType = ZodType,
+  Response extends ZodType = ZodType,
+> = Route extends `${string}/*`
+  ? Pick<
+      DomainIntegrationOptions<Body, Response>,
+      "target" | "maxRetryDelay" | "retryAttempts"
+    >
+  : DomainIntegrationOptions<Body, Response>;
+
+export type IntegrationResult<Data = unknown> =
+  | { readonly ok: true; readonly status: number; readonly data: Data }
+  | {
+      readonly ok: false;
+      readonly error: {
+        readonly status: number;
+        readonly message: string;
+        readonly body?: unknown;
+      };
+    };
+
+export type DomainIntegrations = Readonly<
+  Record<string, (...args: never[]) => Promise<IntegrationResult>>
+>;
+
+interface IntegrationRequestBase extends Pick<
+  FlexFetchRequestInit,
+  "maxRetryDelay" | "retryAttempts"
+> {
+  headers?: Readonly<Record<string, string>>;
+  query?: Readonly<Record<string, string>>;
+}
+
+interface IntegrationRequest<Body = unknown> extends IntegrationRequestBase {
+  path: string;
+  body: Body;
+}
+
+interface IntegrationPathRequest extends IntegrationRequestBase {
+  path: string;
+}
+
+interface IntegrationBodyRequest<
+  Body = unknown,
+> extends IntegrationRequestBase {
+  body: Body;
+}
+
+type InferIntegrationMethod<Integration extends DomainIntegration> =
+  Integration extends {
+    readonly route: `${infer Method extends HttpMethod} ${string}`;
+  }
+    ? Method
+    : never;
+
+type InferIntegrationBody<Integration extends DomainIntegration> =
+  Integration extends { readonly body?: infer Body }
+    ? Body extends ZodType<infer Data>
+      ? Data
+      : unknown
+    : unknown;
+
+type InferIntegrationResponse<Integration extends DomainIntegration> =
+  Integration extends { readonly response?: infer Response }
+    ? Response extends ZodType<infer Data>
+      ? Data
+      : unknown
+    : unknown;
+
+type IsWildcardRoute<Integration extends DomainIntegration> =
+  Integration extends {
+    readonly route: `${HttpMethod} ${string}/*`;
+  }
+    ? true
+    : false;
+
+type IntegrationInvoke<Integration extends DomainIntegration> =
+  IsWildcardRoute<Integration> extends true
+    ? InferIntegrationMethod<Integration> extends HttpMethodWithBody
+      ? <Request, Response = InferIntegrationResponse<Integration>>(
+          options: IntegrationRequest<Request>,
+        ) => Promise<IntegrationResult<Response>>
+      : <Response = InferIntegrationResponse<Integration>>(
+          options: IntegrationPathRequest,
+        ) => Promise<IntegrationResult<Response>>
+    : (
+        options: InferIntegrationMethod<Integration> extends HttpMethodWithBody
+          ? IntegrationBodyRequest<InferIntegrationBody<Integration>>
+          : IntegrationRequestBase,
+      ) => Promise<IntegrationResult<InferIntegrationResponse<Integration>>>;
+
+// ----------------------------------------------------------------------------
+// Integrations / Service Gateway & Domain
+// ----------------------------------------------------------------------------
+
+export interface IntegrationDomainService<
+  Route extends string = string,
+  Body extends ZodType = ZodType,
+  Response extends ZodType = ZodType,
+> extends DomainIntegrationOptions<Body, Response> {
+  readonly type: "domain";
+  readonly route: Route;
+}
+
+export interface IntegrationServiceGateway<
+  Route extends string = string,
+  Body extends ZodType = ZodType,
+  Response extends ZodType = ZodType,
+> extends DomainIntegrationOptions<Body, Response> {
+  readonly type: "gateway";
+  readonly route: Route;
+}
+
+export type DomainIntegration =
+  | IntegrationDomainService
+  | IntegrationServiceGateway;
+
+// ----------------------------------------------------------------------------
+// Utility
+// ----------------------------------------------------------------------------
+
+export type InferResourceKeys<Config extends DomainConfig> = Config extends {
+  readonly resources: Readonly<
+    Record<infer DomainResourceKey extends string, DomainResource>
+  >;
+}
+  ? DomainResourceKey
+  : never;
+
+export type InferIntegrationKeys<Config extends DomainConfig> = Config extends {
+  readonly integrations: Readonly<
+    Record<infer IntegrationKey extends string, DomainIntegration>
+  >;
+}
+  ? IntegrationKey
+  : never;
+
+type ExtractPathParams<Path extends string> =
+  Path extends `${string}:${infer PathParam}/${infer RemainingPath}`
+    ? PathParam | ExtractPathParams<`/${RemainingPath}`>
+    : Path extends `${string}:${infer PathParam}`
+      ? PathParam
+      : never;
+
+type ExtractRouteSegments<Route extends string> =
+  Route extends `${infer Method extends HttpMethod} /${infer Version}/${infer Path} [private]`
+    ? {
+        method: Method;
+        version: Version;
+        path: `/${Path}`;
+        gateway: "private";
+      }
+    : Route extends `${infer Method extends HttpMethod} /${infer Version}/${infer Path}`
+      ? {
+          method: Method;
+          version: Version;
+          path: `/${Path}`;
+          gateway: "public";
+        }
+      : never;
+
+type ExtractRoutePath<Route extends string> =
+  Route extends `${HttpMethod} /${string}/${infer Path} [private]`
+    ? `/${Path}`
+    : Route extends `${HttpMethod} /${string}/${infer Path}`
+      ? `/${Path}`
+      : never;
+
+type ExtractGatewayRouteConfig<
+  Gateway,
+  GatewayAccess extends "public" | "private",
+> = GatewayAccess extends "private"
+  ? Gateway extends { readonly private: infer PrivateRouteConfig }
+    ? PrivateRouteConfig
+    : never
+  : Gateway extends { readonly public: infer PublicRouteConfig }
+    ? PublicRouteConfig
+    : never;
+
+export type DomainRoutes<Config extends DomainConfig> = Config extends {
+  readonly routes: infer ConfigRoutes;
+}
+  ? {
+      [Version in keyof ConfigRoutes & string]: {
+        [Path in keyof ConfigRoutes[Version] & string]: {
+          [Method in keyof ConfigRoutes[Version][Path] & HttpMethod]:
+            | (ConfigRoutes[Version][Path][Method] extends {
+                readonly public: unknown;
+              }
+                ? `${Method} /${Version}${Path}`
+                : never)
+            | (ConfigRoutes[Version][Path][Method] extends {
+                readonly private: unknown;
+              }
+                ? `${Method} /${Version}${Path} [private]`
+                : never);
+        }[keyof ConfigRoutes[Version][Path] & HttpMethod];
+      }[keyof ConfigRoutes[Version] & string];
+    }[keyof ConfigRoutes & string]
+  : never;
+
+type ResolveRouteAccess<Config, RouteConfig> = RouteConfig extends {
+  readonly access: infer Access extends RouteAccess;
+}
+  ? Access
+  : Config extends {
+        readonly common: {
+          readonly access: infer CommonRouteAccess extends RouteAccess;
+        };
+      }
+    ? CommonRouteAccess
+    : "isolated";
+
+export type ResolveRouteConfig<Config, Route extends string> =
+  ExtractRouteSegments<Route> extends {
+    method: infer Method extends HttpMethod;
+    version: infer Version extends string;
+    path: infer Path extends string;
+    gateway: infer Gateway extends "public" | "private";
+  }
+    ? Config extends { readonly routes: infer ConfigRoutes }
+      ? Version extends keyof ConfigRoutes
+        ? Path extends keyof ConfigRoutes[Version]
+          ? Method extends keyof ConfigRoutes[Version][Path]
+            ? ExtractGatewayRouteConfig<
+                ConfigRoutes[Version][Path][Method],
+                Gateway
+              >
+            : never
+          : never
+        : never
+      : never
+    : never;
+
+// ----------------------------------------------------------------------------
+// Lambda
+// ----------------------------------------------------------------------------
+
+export interface LambdaAuthorizerContext {
+  readonly pairwiseId?: string;
+}
+
+export type LambdaEvent = APIGatewayProxyEventBase<LambdaAuthorizerContext>;
+
+export type LambdaContext = Context;
+
+export type LambdaResult = APIGatewayProxyResult;
+
+// ----------------------------------------------------------------------------
+// Route Gateway
+// ----------------------------------------------------------------------------
+
+export type GatewayRouteConfig<
+  Method extends HttpMethod,
+  ResourceKeys extends string = string,
+  IntegrationKeys extends string = string,
+> =
+  | {
+      readonly public: MethodRouteConfig<Method, ResourceKeys, IntegrationKeys>;
+      readonly private?: MethodRouteConfig<
+        Method,
+        ResourceKeys,
+        IntegrationKeys
+      >;
+    }
+  | {
+      readonly public?: MethodRouteConfig<
+        Method,
+        ResourceKeys,
+        IntegrationKeys
+      >;
+      readonly private: MethodRouteConfig<
+        Method,
+        ResourceKeys,
+        IntegrationKeys
+      >;
+    };
+
+// ----------------------------------------------------------------------------
+// Domain Config
+// ----------------------------------------------------------------------------
+
+export type HttpMethod =
+  | "GET"
+  | "POST"
+  | "PUT"
+  | "PATCH"
+  | "DELETE"
+  | "HEAD"
+  | "OPTIONS";
+
+type HttpMethodWithBody = Extract<HttpMethod, "POST" | "PUT" | "PATCH">;
+
+export type LogLevel =
+  | "TRACE"
+  | "DEBUG"
+  | "INFO"
+  | "WARN"
+  | "ERROR"
+  | "SILENT"
+  | "CRITICAL";
+
+export type RouteAccess = "public" | "private" | "isolated";
+
+interface DomainConfigCommon {
+  readonly access?: RouteAccess;
+  readonly logLevel?: LogLevel;
+  readonly function?: FunctionConfig;
+  readonly headers?: Readonly<Record<string, HeaderConfig>>;
+}
+
+type MethodRouteConfig<
+  Method extends HttpMethod,
+  ResourceKeys extends string = string,
+  IntegrationKeys extends string = string,
+> = {
+  readonly name: string;
+  readonly access?: RouteAccess;
+  readonly function?: FunctionConfig;
+  readonly body?: Method extends HttpMethodWithBody ? ZodType : never;
+  readonly logLevel?: LogLevel;
+  readonly query?: ZodType;
+  readonly response?: ZodType;
+  readonly resources?: readonly ResourceKeys[];
+  readonly integrations?: readonly IntegrationKeys[];
+  readonly headers?: Readonly<Record<string, HeaderConfig>>;
+};
+
+type PathRoutes<
+  ResourceKeys extends string = string,
+  IntegrationKeys extends string = string,
+> = {
+  readonly [Method in HttpMethod]?: GatewayRouteConfig<
+    Method,
+    ResourceKeys,
+    IntegrationKeys
+  >;
+};
+
+type VersionRoutes<
+  ResourceKeys extends string = string,
+  IntegrationKeys extends string = string,
+> = Readonly<Record<string, PathRoutes<ResourceKeys, IntegrationKeys>>>;
+
+export interface DomainConfig<
+  ResourceKeys extends string = string,
+  IntegrationKeys extends string = string,
+> {
+  readonly name: string;
+  readonly routes: Readonly<
+    Record<
+      string,
+      VersionRoutes<NoInfer<ResourceKeys>, NoInfer<IntegrationKeys>>
+    >
+  >;
+  readonly common?: DomainConfigCommon;
+  readonly owner?: string;
+  readonly resources?: Readonly<Record<ResourceKeys, DomainResource>>;
+  readonly integrations?: Readonly<Record<IntegrationKeys, DomainIntegration>>;
+}
+
+export interface DomainResult<Config extends DomainConfig> {
+  readonly config: Config;
+  readonly route: RouteHandler<Config>;
+  readonly routeContext: <Route extends DomainRoutes<Config> = never>() => [
+    Route,
+  ] extends [never]
+    ? '[ERROR] Must provide a generic type matching a known domain route key. E.g. routeContext<"GET /v1/path">()'
+    : InferRouteContext<Config, Route>;
+}
+
+// ----------------------------------------------------------------------------
+// Route Context & Handler
+// ----------------------------------------------------------------------------
+
+type WithAuth<Access extends RouteAccess> = Access extends "public"
+  ? unknown
+  : { readonly auth: RouteAuth };
+
+type WithHeaders<Config extends DomainConfig, RouteConfig> = ResolveHeaders<
+  MergeRouteHeaders<Config, RouteConfig>
+>;
+
+type WithResources<RouteConfig> = RouteConfig extends {
+  readonly resources: readonly (infer ResourceKey extends string)[];
+}
+  ? [ResourceKey] extends [never]
+    ? unknown
+    : { readonly resources: { readonly [Key in ResourceKey]: string } }
+  : unknown;
+
+type WithIntegrations<
+  Config extends DomainConfig,
+  RouteConfig,
+> = RouteConfig extends {
+  readonly integrations: readonly (infer IntegrationKey extends string)[];
+}
+  ? Config extends {
+      readonly integrations: infer RouteIntegrations extends Readonly<
+        Record<string, DomainIntegration>
+      >;
+    }
+    ? [IntegrationKey] extends [never]
+      ? unknown
+      : {
+          readonly integrations: {
+            readonly [Key in IntegrationKey]: Key extends keyof RouteIntegrations
+              ? IntegrationInvoke<RouteIntegrations[Key]>
+              : never;
+          };
+        }
+    : unknown
+  : unknown;
+
+type WithPathParams<Path extends string> = [ExtractPathParams<Path>] extends [
+  never,
+]
+  ? unknown
+  : {
+      readonly pathParams: {
+        readonly [Key in ExtractPathParams<Path>]: string;
+      };
+    };
+
+type WithQueryParams<RouteConfig> = RouteConfig extends {
+  readonly query: ZodType<infer QueryParams>;
+}
+  ? { readonly queryParams: QueryParams }
+  : unknown;
+
+type WithBody<RouteConfig> = RouteConfig extends {
+  readonly body: ZodType<infer Body>;
+}
+  ? { readonly body: Body }
+  : unknown;
+
+export interface RouteAuth {
+  readonly pairwiseId: string;
+}
+
+interface HandlerSuccessResult {
+  readonly status: number;
+  readonly data?: unknown;
+  readonly error?: never;
+}
+
+interface HandlerErrorResult {
+  readonly status: number;
+  readonly data?: never;
+  readonly error?: unknown;
+}
+
+interface HandlerNoContentResult {
+  status: number;
+  readonly data?: never;
+  readonly error?: never;
+}
+
+export type HandlerResult =
+  | HandlerSuccessResult
+  | HandlerErrorResult
+  | HandlerNoContentResult;
+
+type RouteHandlerResult<RouteConfig> = RouteConfig extends {
+  readonly response: ZodType<infer Data>;
+}
+  ?
+      | { readonly status: number; readonly data: Data; readonly error?: never }
+      | {
+          readonly status: number;
+          readonly data?: never;
+          readonly error?: unknown;
+        }
+  : HandlerResult;
+
+type RouteContext<
+  Route extends string,
+  Config extends DomainConfig,
+  RouteConfig,
+> = { readonly logger: Logger } & WithAuth<
+  ResolveRouteAccess<Config, RouteConfig>
+> &
+  WithResources<RouteConfig> &
+  WithIntegrations<Config, RouteConfig> &
+  WithHeaders<Config, RouteConfig> &
+  WithPathParams<ExtractRoutePath<Route>> &
+  WithQueryParams<RouteConfig> &
+  WithBody<RouteConfig>;
+
+export type FlexLambdaHandler = (
+  event: LambdaEvent,
+  context: LambdaContext,
+) => Promise<LambdaResult>;
+
+export interface RouteHandler<Config extends DomainConfig> {
+  <const Route extends DomainRoutes<Config>>(
+    route: Route,
+    handler: (
+      context: RouteContext<Route, Config, ResolveRouteConfig<Config, Route>>,
+    ) => Promise<RouteHandlerResult<ResolveRouteConfig<Config, Route>>>,
+  ): FlexLambdaHandler;
+}
+
+export type InferRouteContext<
+  Config extends DomainConfig,
+  Route extends DomainRoutes<Config>,
+> = RouteContext<Route, Config, ResolveRouteConfig<Config, Route>>;

--- a/libs/sdk/src/utils/cache.ts
+++ b/libs/sdk/src/utils/cache.ts
@@ -1,0 +1,13 @@
+export function cache<Fn>(fn: () => Fn): () => Fn {
+  let result: Fn;
+  let called: boolean = false;
+
+  return () => {
+    if (!called) {
+      result = fn();
+      called = true;
+    }
+
+    return result;
+  };
+}

--- a/libs/sdk/src/utils/errors.ts
+++ b/libs/sdk/src/utils/errors.ts
@@ -1,0 +1,20 @@
+export class HeaderValidationError extends Error {
+  readonly statusCode = 400;
+  readonly headers: readonly string[];
+
+  constructor(headers: readonly string[]) {
+    super(`Missing headers: ${headers.join(", ")}`);
+
+    this.name = "HeaderValidationError";
+    this.headers = headers;
+  }
+}
+
+export class RequestBodyParseError extends Error {
+  public readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "RequestBodyParseError";
+  }
+}

--- a/libs/sdk/src/utils/index.ts
+++ b/libs/sdk/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { cache } from "./cache";

--- a/libs/utils/src/infra/index.ts
+++ b/libs/utils/src/infra/index.ts
@@ -25,7 +25,7 @@ export function sanitiseStageName(value?: string) {
 
   return value
     .toLowerCase()
-    .replace(/[^a-z0-9-]/g, "")
+    .replace(/[^a-z0-9]/g, "")
     .slice(0, 12);
 }
 

--- a/platform/infra/flex/src/app.ts
+++ b/platform/infra/flex/src/app.ts
@@ -3,12 +3,9 @@ import * as cdk from "aws-cdk-lib";
 
 import { FlexCertStack } from "./stacks/cert";
 import { FlexPlatformStack } from "./stacks/core";
-import { FlexDomainStack } from "./stacks/domain";
+import { FlexDomainStack, FlexDomainStackPoC } from "./stacks/domain";
 import { FlexPrivateGatewayStack } from "./stacks/private-gateway";
-import {
-  getDomainConfigs,
-  getPrivateDomainConfigs,
-} from "./utils/getDomainConfigs";
+import { getDomainConfigs } from "./utils/getDomainConfigs";
 import { getDomainName } from "./utils/getDomainName";
 
 const app = new cdk.App();
@@ -16,6 +13,7 @@ const app = new cdk.App();
 const { domainName, subdomainName } = await getDomainName();
 
 const certStackName = getStackName("FlexCertStack");
+
 const { certArnParamName } = new FlexCertStack(app, certStackName, {
   domainName,
   subdomainName,
@@ -32,32 +30,49 @@ const privateGateway = new FlexPrivateGatewayStack(
  */
 const targetDomain = process.env.domain;
 
-const allDomains = await getDomainConfigs();
-const privateDomains = await getPrivateDomainConfigs();
+// TODO: Reduce down to single list once PoC migration is complete
+const domains = await getDomainConfigs();
 
-const flexDomains = targetDomain
-  ? allDomains.filter((d) => d.domain === targetDomain)
-  : allDomains;
+const pocDomains = targetDomain
+  ? domains.poc.filter((d) => d.name === targetDomain)
+  : domains.poc;
 
-if (targetDomain && flexDomains.length === 0) {
-  const available = allDomains.map((d) => d.domain).join(", ");
-  throw new Error(
-    `Domain '${targetDomain}' not found. Available domains: ${available}`,
-  );
-}
-
-const domainStacks = flexDomains.map(
-  (domain) =>
-    new FlexDomainStack(app, getStackName(domain.domain), {
-      domain,
+const pocStacks = pocDomains.map(
+  (config) =>
+    new FlexDomainStackPoC(app, getStackName(config.name), {
+      config,
       privateApi: privateGateway.privateApiRef,
-      privateDomain: privateDomains.get(domain.domain),
     }),
 );
 
-const publicRouteBindings = domainStacks.flatMap(
-  (stack) => stack.publicRouteBindings,
+const legacyDomains = targetDomain
+  ? domains.endpoints.filter((d) => d.public.domain === targetDomain)
+  : domains.endpoints;
+
+const legacyStacks = legacyDomains.map(
+  (configs) =>
+    new FlexDomainStack(app, getStackName(configs.public.domain), {
+      domain: configs.public,
+      privateDomain: configs.private,
+      privateApi: privateGateway.privateApiRef,
+    }),
 );
+
+const publicRouteBindings = [
+  ...pocStacks.flatMap((s) => s.publicRouteBindings),
+  ...legacyStacks.flatMap((s) => s.publicRouteBindings),
+];
+
+if (targetDomain && pocDomains.length === 0 && legacyDomains.length === 0) {
+  const available = [
+    ...domains.poc.map((d) => d.name),
+    ...domains.endpoints.map((d) => d.public.domain),
+  ].join(", ");
+
+  throw new Error(
+    `Domain "${targetDomain}" not found. Available domains: ${available}`,
+  );
+}
 
 new FlexPlatformStack(app, getStackName("FlexPlatform"), {
   certArnParamName,

--- a/platform/infra/flex/src/stacks/core.ts
+++ b/platform/infra/flex/src/stacks/core.ts
@@ -1,10 +1,6 @@
 import { GovUkOnceStack } from "@platform/gov-uk-once";
 import { CfnOutput } from "aws-cdk-lib";
-import {
-  IResource,
-  LambdaIntegration,
-  RestApi,
-} from "aws-cdk-lib/aws-apigateway";
+import { LambdaIntegration } from "aws-cdk-lib/aws-apigateway";
 import { Certificate } from "aws-cdk-lib/aws-certificatemanager";
 import { PolicyStatement } from "aws-cdk-lib/aws-iam";
 import {
@@ -16,7 +12,9 @@ import type { Construct } from "constructs";
 
 import { FlexRestApi } from "../constructs/api-gateway/flex-rest-api";
 import { FlexCloudfront } from "../constructs/cloudfront/flex-cloudfront";
-import { PublicRouteBinding } from "./domain";
+import { applyCheckovSkip } from "../utils/applyCheckovSkip";
+import { resolveApiResource } from "../utils/resources";
+import type { PublicRouteBinding } from "./domain";
 
 interface FlexPlatformStackProps {
   certArnParamName: string;
@@ -26,8 +24,6 @@ interface FlexPlatformStackProps {
 }
 
 export class FlexPlatformStack extends GovUkOnceStack {
-  public readonly restApi: RestApi;
-
   #getCertArn(certArnParamName: string) {
     const ssmCall = {
       service: "SSM",
@@ -80,7 +76,7 @@ export class FlexPlatformStack extends GovUkOnceStack {
     });
 
     const { restApi } = new FlexRestApi(this, "RestApi");
-    this.restApi = restApi;
+
     const certArn = this.#getCertArn(certArnParamName);
 
     new FlexCloudfront(this, "Cloudfront", {
@@ -91,30 +87,20 @@ export class FlexPlatformStack extends GovUkOnceStack {
     });
 
     for (const route of publicRouteBindings) {
-      this.#addDeepResource(restApi.root, route.path).addMethod(
+      const resource = resolveApiResource(restApi.root, route.path);
+
+      const resourceMethod = resource.addMethod(
         route.method,
         new LambdaIntegration(route.handler),
       );
+
+      if (route.isPublicAccess) {
+        applyCheckovSkip(resourceMethod, "CKV_AWS_59", "Known public endpoint");
+      }
     }
 
     new CfnOutput(this, "FlexApiUrl", {
       value: `https://${subdomainName ?? domainName}`,
     });
-  }
-
-  #addDeepResource(root: IResource, path: string): IResource {
-    const parts = path.split("/").filter(Boolean);
-    let current = root;
-
-    for (const part of parts) {
-      const existing = current.node.tryFindChild(part) as IResource | undefined;
-      if (existing) {
-        current = existing;
-      } else {
-        current = current.addResource(part);
-      }
-    }
-
-    return current;
   }
 }

--- a/platform/infra/flex/src/stacks/domain.ts
+++ b/platform/infra/flex/src/stacks/domain.ts
@@ -1,4 +1,10 @@
-import { IDomain, IDomainEndpoint, Permission } from "@flex/sdk";
+import type {
+  IacDomainConfig,
+  IDomain,
+  IDomainEndpoint,
+  Permission,
+  RouteAccess,
+} from "@flex/sdk";
 import {
   FlexKmsKeyAlias,
   FlexParam,
@@ -9,18 +15,18 @@ import {
 } from "@platform/core/outputs";
 import { GovUkOnceStack } from "@platform/gov-uk-once";
 import { Duration } from "aws-cdk-lib";
+import type { IResource, IRestApi } from "aws-cdk-lib/aws-apigateway";
 import {
-  IResource,
-  IRestApi,
   LambdaIntegration,
   Resource,
   RestApi,
 } from "aws-cdk-lib/aws-apigateway";
-import { IRole } from "aws-cdk-lib/aws-iam";
-import { IKey } from "aws-cdk-lib/aws-kms";
-import { IFunction } from "aws-cdk-lib/aws-lambda";
-import { ISecret } from "aws-cdk-lib/aws-secretsmanager";
-import { IStringParameter, StringParameter } from "aws-cdk-lib/aws-ssm";
+import type { IRole } from "aws-cdk-lib/aws-iam";
+import type { IKey } from "aws-cdk-lib/aws-kms";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
+import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+import type { IStringParameter } from "aws-cdk-lib/aws-ssm";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import type { Construct } from "constructs";
 import crypto from "crypto";
 
@@ -31,13 +37,21 @@ import { applyCheckovSkip } from "../utils/applyCheckovSkip";
 import { getDomainEntry } from "../utils/getEntry";
 import { FlexEphemeralParam, getParamName } from "../utils/getParamName";
 import { grantPrivateApiAccess } from "../utils/grantPrivateApiAccess";
-import { PrivateApiRef } from "./private-gateway";
-
-export interface PublicRouteBinding {
-  path: string;
-  method: string;
-  handler: IFunction;
-}
+import { grantRoutePermissions } from "../utils/integrations";
+import { toFunctionConfig } from "../utils/lambda";
+import {
+  grantRouteResources,
+  importResources,
+  resolveApiResource,
+} from "../utils/resources";
+import {
+  flattenRoutes,
+  getFunctionAccess,
+  resolveRouteReferences,
+  toApiGatewayPath,
+  toPascalCase,
+} from "../utils/routes";
+import type { PrivateApiRef } from "./private-gateway";
 
 interface FlexDomainStackProps {
   domain: IDomain;
@@ -62,6 +76,7 @@ export class FlexDomainStack extends GovUkOnceStack {
         Source: "https://github.com/govuk-once/flex",
       },
     });
+
     const privateApi = RestApi.fromRestApiAttributes(this, "PrivateApi", {
       restApiId: props.privateApi.restApiId,
       rootResourceId: props.privateApi.domainsRootResourceId,
@@ -130,6 +145,8 @@ export class FlexDomainStack extends GovUkOnceStack {
             path: newPath,
             method,
             handler: domainEndpointFn.function,
+            // NOTE: Default to false, this field is used in PoC
+            isPublicAccess: false,
           });
         }
       }
@@ -383,5 +400,148 @@ export class FlexDomainStack extends GovUkOnceStack {
       allowedRoutePrefixes,
       allowedMethods,
     });
+  }
+}
+
+// ----------------------------------------------------------------------------
+// PoC
+// ----------------------------------------------------------------------------
+
+export interface PublicRouteBinding {
+  readonly handler: IFunction;
+  readonly method: string;
+  readonly path: string;
+  readonly isPublicAccess: boolean;
+}
+
+interface FlexDomainStackPoCProps {
+  config: IacDomainConfig;
+  privateApi: PrivateApiRef;
+}
+
+export class FlexDomainStackPoC extends GovUkOnceStack {
+  public readonly publicRouteBindings: PublicRouteBinding[] = [];
+
+  constructor(
+    scope: Construct,
+    id: string,
+    { config, privateApi }: FlexDomainStackPoCProps,
+  ) {
+    super(scope, id, {
+      tags: {
+        Product: "GOV.UK",
+        System: "FLEX",
+        Owner: config.owner ?? "N/A",
+        ResourceOwner: config.name,
+        Source: "https://github.com/govuk-once/flex",
+      },
+    });
+
+    const privateRestApi = RestApi.fromRestApiAttributes(this, "PrivateApi", {
+      restApiId: privateApi.restApiId,
+      rootResourceId: privateApi.domainsRootResourceId,
+    });
+
+    const privateDomainsRoot = Resource.fromResourceAttributes(
+      this,
+      "PrivateDomainsRoot",
+      {
+        path: "/domains",
+        resourceId: privateApi.domainsRootResourceId,
+        restApi: privateRestApi,
+      },
+    );
+
+    const routes = flattenRoutes(config.routes);
+
+    const [resourceReferences, integrationReferences] = resolveRouteReferences(
+      routes,
+      { resources: config.resources, integrations: config.integrations },
+    );
+
+    const resources = importResources(this, resourceReferences);
+
+    routes.forEach(
+      ({ gateway, handlerPath, method, path, routeConfig, version }) => {
+        const functionId = toPascalCase(
+          `${config.name}-${gateway}-${version}-${routeConfig.name}`,
+        );
+        const routeAccess = getFunctionAccess(
+          routeConfig.access,
+          config.common?.access,
+        );
+
+        const lambda = this.#createFunction(functionId, routeAccess, {
+          domain: config.name,
+          entry: getDomainEntry(config.name, handlerPath),
+          ...toFunctionConfig(routeConfig.function, config.common?.function),
+        });
+
+        if (routeConfig.resources?.length) {
+          grantRouteResources(lambda.function, {
+            keys: routeConfig.resources,
+            resources,
+          });
+        }
+
+        if (routeConfig.integrations?.length) {
+          grantRoutePermissions(lambda.function, {
+            keys: routeConfig.integrations,
+            integrations: integrationReferences,
+            api: privateRestApi,
+            domain: config.name,
+          });
+        }
+
+        const resourcePath = toApiGatewayPath({
+          domain: config.name,
+          gateway,
+          version,
+          path,
+        });
+
+        if (gateway === "public") {
+          this.publicRouteBindings.push({
+            handler: lambda.function,
+            method,
+            path: resourcePath,
+            isPublicAccess: routeAccess === "public",
+          });
+        }
+
+        if (gateway === "private") {
+          const resource = resolveApiResource(privateDomainsRoot, resourcePath);
+
+          const resourceMethod = resource.addMethod(
+            method,
+            new LambdaIntegration(lambda.function),
+          );
+
+          applyCheckovSkip(
+            resourceMethod,
+            "CKV_AWS_59",
+            "Private API - access restricted by VPC endpoint and resource policy",
+          );
+        }
+      },
+    );
+  }
+
+  #createFunction(
+    id: string,
+    access: RouteAccess,
+    props: ReturnType<typeof toFunctionConfig> & {
+      domain: string;
+      entry: string;
+    },
+  ) {
+    switch (access) {
+      case "isolated":
+        return new FlexPrivateIsolatedFunction(this, id, props);
+      case "private":
+        return new FlexPrivateEgressFunction(this, id, props);
+      case "public":
+        return new FlexPublicFunction(this, id, props);
+    }
   }
 }

--- a/platform/infra/flex/src/stacks/private-gateway.ts
+++ b/platform/infra/flex/src/stacks/private-gateway.ts
@@ -26,8 +26,8 @@ export class FlexPrivateGatewayStack extends GovUkOnceStack {
     });
 
     const internalGateway = new FlexInternalGateway(this, "InternalGateway");
-    this.internalGateway = internalGateway;
 
+    this.internalGateway = internalGateway;
     this.privateApiRef = {
       restApiId: internalGateway.privateGateway.restApiId,
       stageName: internalGateway.privateGateway.deploymentStage.stageName,

--- a/platform/infra/flex/src/utils/create-hash.ts
+++ b/platform/infra/flex/src/utils/create-hash.ts
@@ -1,0 +1,25 @@
+import type { BinaryToTextEncoding } from "node:crypto";
+import crypto from "node:crypto";
+
+interface CreateHashOptions {
+  algorithm?: string;
+  encoding?: BinaryToTextEncoding;
+  start?: number;
+  end?: number;
+}
+
+export function createHash(
+  value: string,
+  {
+    algorithm = "md5",
+    encoding = "hex",
+    start = 0,
+    end = 16,
+  }: CreateHashOptions = {},
+) {
+  return crypto
+    .createHash(algorithm)
+    .update(value)
+    .digest(encoding)
+    .slice(start, end);
+}

--- a/platform/infra/flex/src/utils/createPrivateGatewayRoute.ts
+++ b/platform/infra/flex/src/utils/createPrivateGatewayRoute.ts
@@ -1,5 +1,6 @@
-import { IResource, LambdaIntegration } from "aws-cdk-lib/aws-apigateway";
-import { IFunction } from "aws-cdk-lib/aws-lambda";
+import type { IResource } from "aws-cdk-lib/aws-apigateway";
+import { LambdaIntegration } from "aws-cdk-lib/aws-apigateway";
+import type { IFunction } from "aws-cdk-lib/aws-lambda";
 
 export function createPrivateGatewayRoute(
   path: string,

--- a/platform/infra/flex/src/utils/getDomainConfigs.ts
+++ b/platform/infra/flex/src/utils/getDomainConfigs.ts
@@ -1,7 +1,13 @@
+import fs from "node:fs";
 import { glob } from "node:fs/promises";
 import path from "node:path";
 
-import { domainSchema, IDomain } from "@flex/sdk";
+import {
+  DomainConfigSchema,
+  domainSchema,
+  IacDomainConfig,
+  IDomain,
+} from "@flex/sdk";
 import { findProjectRoot } from "@flex/utils";
 import { createJiti } from "jiti";
 import z from "zod";
@@ -11,31 +17,62 @@ const configModuleSchema = z.object({
 });
 
 const jiti = createJiti(import.meta.url);
+
 const domainsRoot = `${findProjectRoot()}/domains`;
 
-const loadDomainConfigs = async (pattern: string): Promise<IDomain[]> => {
-  const results: IDomain[] = [];
-  for await (const entry of glob(pattern, { cwd: domainsRoot })) {
-    const absolutePath = path.join(domainsRoot, entry);
-    const configModule = await jiti.import(absolutePath);
-    const { success, data } = configModuleSchema.safeParse(configModule);
-
-    if (!success) {
-      throw new Error(`Config invalid: ${absolutePath}`);
-    }
-    results.push(data.endpoints);
-  }
-  return results;
-};
-
-export async function getDomainConfigs(): Promise<IDomain[]> {
-  return loadDomainConfigs("*/domain.config.ts");
+interface LegacyDomainConfigs {
+  public: IDomain;
+  private?: IDomain;
 }
 
-/**
- * Returns a Map of domain name to private config
- */
-export async function getPrivateDomainConfigs(): Promise<Map<string, IDomain>> {
-  const privateConfigs = await loadDomainConfigs("*/domain.private.config.ts");
-  return new Map(privateConfigs.map((config) => [config.domain, config]));
+// TODO: Return single list of domains when poc migration is complete
+interface DomainConfigs {
+  endpoints: LegacyDomainConfigs[];
+  poc: IacDomainConfig[];
+}
+
+export async function getDomainConfigs(): Promise<DomainConfigs> {
+  const domains: DomainConfigs = { endpoints: [], poc: [] };
+
+  for await (const entry of glob("*/domain.config.ts", { cwd: domainsRoot })) {
+    const absolutePath = path.join(domainsRoot, entry);
+
+    const file = await jiti.import<
+      { config: IacDomainConfig } | { endpoints: IDomain }
+    >(absolutePath);
+
+    if ("config" in file) {
+      const { data, error } = DomainConfigSchema.safeParse(file.config);
+
+      if (error) throw new Error(`Invalid domain config: ${absolutePath}`);
+
+      domains.poc.push(data);
+      continue;
+    }
+
+    const { data, error } = configModuleSchema.safeParse(file);
+
+    if (error) throw new Error(`Invalid domain config: ${absolutePath}`);
+
+    domains.endpoints.push({
+      public: data.endpoints,
+      private: await loadDomainPrivateConfig(path.dirname(absolutePath)),
+    });
+  }
+
+  return domains;
+}
+
+async function loadDomainPrivateConfig(dir: string) {
+  const file = path.join(dir, "domain.private.config.ts");
+
+  if (!fs.existsSync(file)) return;
+
+  const { data, error } = configModuleSchema.safeParse(
+    await jiti.import<IDomain>(file),
+  );
+
+  if (error) throw new Error(`Invalid domain config: ${file}`);
+
+  return data.endpoints;
 }

--- a/platform/infra/flex/src/utils/integrations.ts
+++ b/platform/infra/flex/src/utils/integrations.ts
@@ -1,0 +1,86 @@
+import type { DomainIntegration, HttpMethod } from "@flex/sdk";
+import { extractRouteKeySegments } from "@flex/sdk";
+import type { IRestApi } from "aws-cdk-lib/aws-apigateway";
+import { Effect, PolicyStatement } from "aws-cdk-lib/aws-iam";
+import type { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+
+import { toPascalCase } from "./routes";
+
+interface PermissionGrant {
+  routePrefix: string;
+  method: HttpMethod;
+}
+
+function toPermissionGrant(
+  { route, type, target }: DomainIntegration,
+  domain: string,
+): PermissionGrant {
+  const prefix = type === "domain" ? "domains" : "gateways";
+
+  const { method, version, path } = extractRouteKeySegments(route);
+
+  return {
+    method,
+    routePrefix: `/${prefix}/${target ?? domain}/${version}${path}`,
+  };
+}
+
+function getMethodPermissionGrants(
+  permissionGrants: readonly PermissionGrant[],
+): ReadonlyMap<HttpMethod, readonly string[]> {
+  const grants = new Map<HttpMethod, string[]>();
+
+  for (const { method, routePrefix } of permissionGrants) {
+    const group = grants.get(method);
+
+    if (group) {
+      if (!group.includes(routePrefix)) group.push(routePrefix);
+    } else {
+      grants.set(method, [routePrefix]);
+    }
+  }
+
+  return grants;
+}
+
+interface RoutePermissionOption {
+  keys: readonly string[];
+  integrations: ReadonlyMap<string, DomainIntegration>;
+  domain: string;
+  api: IRestApi;
+}
+
+export function grantRoutePermissions(
+  target: NodejsFunction,
+  { keys, integrations, domain, api }: RoutePermissionOption,
+) {
+  if (!target.role || keys.length === 0) return;
+
+  const grants = keys.map((key) => {
+    const integration = integrations.get(key);
+
+    if (!integration) {
+      throw new Error(
+        `"${key}" was referenced in "integrations" but has not been resolved`,
+      );
+    }
+
+    return toPermissionGrant(integration, domain);
+  });
+
+  for (const [method, routes] of getMethodPermissionGrants(grants)) {
+    const resources = routes.map((prefix) =>
+      api.arnForExecuteApi(method, prefix, "*"),
+    );
+
+    target.role.addToPrincipalPolicy(
+      new PolicyStatement({
+        sid: `AllowApiAccess${toPascalCase(domain)}${method}`,
+        effect: Effect.ALLOW,
+        actions: ["execute-api:Invoke"],
+        resources,
+        conditions: { StringEquals: { "execute-api:Method": [method] } },
+      }),
+    );
+  }
+}

--- a/platform/infra/flex/src/utils/lambda.ts
+++ b/platform/infra/flex/src/utils/lambda.ts
@@ -1,0 +1,17 @@
+import type { FunctionConfig } from "@flex/sdk";
+import { Duration } from "aws-cdk-lib";
+
+export function toFunctionConfig(
+  route?: FunctionConfig,
+  common?: FunctionConfig,
+) {
+  const environment = { ...common?.environment, ...route?.environment };
+  const memorySize = route?.memorySize ?? common?.memorySize;
+  const timeoutSeconds = route?.timeoutSeconds ?? common?.timeoutSeconds ?? 15;
+
+  return {
+    ...(Object.keys(environment).length > 0 && { environment }),
+    ...(memorySize && { memorySize }),
+    ...(timeoutSeconds && { timeout: Duration.seconds(timeoutSeconds) }),
+  };
+}

--- a/platform/infra/flex/src/utils/resources.ts
+++ b/platform/infra/flex/src/utils/resources.ts
@@ -1,0 +1,144 @@
+import type { DomainResource } from "@flex/sdk";
+import type {
+  FlexKmsKeyAlias,
+  FlexParam,
+  FlexSecret,
+} from "@platform/core/outputs";
+import {
+  importFlexKmsKeyAlias,
+  importFlexParameter,
+  importFlexSecret,
+} from "@platform/core/outputs";
+import type { IResource } from "aws-cdk-lib/aws-apigateway";
+import type { IKey } from "aws-cdk-lib/aws-kms";
+import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import type { ISecret } from "aws-cdk-lib/aws-secretsmanager";
+import type { IStringParameter } from "aws-cdk-lib/aws-ssm";
+import { StringParameter } from "aws-cdk-lib/aws-ssm";
+import type { Construct } from "constructs";
+
+import { createHash } from "./create-hash";
+import { getParamName } from "./getParamName";
+
+export type ImportedResource =
+  | { readonly type: "secret"; readonly construct: ISecret }
+  | { readonly type: "ssm"; readonly construct: IStringParameter }
+  | { readonly type: "ssm:runtime"; readonly construct: IStringParameter }
+  | { readonly type: "kms"; readonly construct: IKey };
+
+export type ImportedResources = ReadonlyMap<string, ImportedResource>;
+
+function importResource(
+  scope: Construct,
+  { type, path, scope: resourceScope }: DomainResource,
+): ImportedResource {
+  const isStageScoped = resourceScope === "stage";
+
+  switch (type) {
+    case "kms":
+      return {
+        type: "kms",
+        construct: importFlexKmsKeyAlias(scope, path as FlexKmsKeyAlias),
+      };
+    case "secret":
+      return {
+        type: "secret",
+        construct: importFlexSecret(
+          scope,
+          (isStageScoped ? getParamName(path) : path) as FlexSecret,
+        ),
+      };
+    case "ssm":
+    case "ssm:runtime":
+      return {
+        type,
+        construct: isStageScoped
+          ? StringParameter.fromStringParameterName(
+              scope,
+              `EphemeralParam${createHash(path)}`,
+              getParamName(path),
+            )
+          : importFlexParameter(scope, path as FlexParam),
+      };
+    default:
+      throw new Error(`Unsupported resource type: ${type}`);
+  }
+}
+
+export function importResources(
+  scope: Construct,
+  references: ReadonlyMap<string, DomainResource>,
+): ImportedResources {
+  const cache = new Map<string, ImportedResource>();
+
+  return new Map(
+    Array.from(references).map(([key, resource]) => {
+      const cached = cache.get(resource.path);
+
+      if (cached) return [key, cached] as const;
+
+      const value = importResource(scope, resource);
+
+      cache.set(resource.path, value);
+
+      return [key, value] as const;
+    }),
+  );
+}
+
+interface RouteResource {
+  keys: readonly string[];
+  resources: ImportedResources;
+}
+
+export function grantRouteResources(
+  target: NodejsFunction,
+  { keys, resources }: RouteResource,
+) {
+  keys.forEach((key) => {
+    const resource = resources.get(key);
+
+    if (!resource) {
+      throw new Error(
+        `"${key}" was referenced in "resources" but has not been resolved`,
+      );
+    }
+
+    const { type, construct } = resource;
+
+    switch (type) {
+      case "kms":
+        construct.grantDecrypt(target);
+        target.addEnvironment(key, construct.keyArn);
+        break;
+      case "secret":
+        construct.grantRead(target);
+        target.addEnvironment(key, construct.secretName);
+        break;
+      case "ssm":
+        construct.grantRead(target);
+        target.addEnvironment(key, construct.stringValue);
+        break;
+      case "ssm:runtime":
+        construct.grantRead(target);
+        target.addEnvironment(key, construct.parameterName);
+        break;
+      default:
+        throw new Error("Unsupported resource type");
+    }
+  });
+}
+
+export function resolveApiResource(target: IResource, path: string) {
+  const parts = path.split("/").filter(Boolean);
+
+  let current = target;
+
+  for (const part of parts) {
+    current =
+      (current.node.tryFindChild(part) as IResource | undefined) ??
+      current.addResource(part);
+  }
+
+  return current;
+}

--- a/platform/infra/flex/src/utils/routes.ts
+++ b/platform/infra/flex/src/utils/routes.ts
@@ -1,0 +1,142 @@
+import type {
+  DomainIntegration,
+  DomainResource,
+  HttpMethod,
+  IacDomainConfig,
+  RouteAccess,
+} from "@flex/sdk";
+
+type RouteGateway = NonNullable<
+  IacDomainConfig["routes"][string][string][HttpMethod]
+>;
+
+export interface FlatRoute {
+  readonly version: string;
+  readonly path: string;
+  readonly method: HttpMethod;
+  readonly gateway: "public" | "private";
+  readonly handlerPath: string;
+  readonly routeConfig: NonNullable<RouteGateway["public" | "private"]>;
+}
+
+export function flattenRoutes(
+  routes: IacDomainConfig["routes"],
+): readonly FlatRoute[] {
+  const entries: FlatRoute[] = [];
+
+  for (const [version, paths] of Object.entries(routes)) {
+    for (const [path, methods] of Object.entries(paths)) {
+      for (const [method, gateways] of Object.entries(methods)) {
+        if (!gateways) continue;
+
+        for (const gateway of ["public", "private"] as const) {
+          const routeConfig = gateways[gateway];
+
+          if (routeConfig) {
+            entries.push({
+              version,
+              path,
+              method: method as HttpMethod,
+              gateway,
+              handlerPath: toHandlerPath(version, path, method, { gateway }),
+              routeConfig,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  return entries;
+}
+
+function resolveKeys<Definition>(
+  keys: ReadonlySet<string>,
+  definitions: Record<string, Definition> | undefined,
+  fieldName: string,
+): ReadonlyMap<string, Definition> {
+  if (!definitions) return new Map();
+
+  return new Map(
+    Array.from(keys).map((key) => {
+      const value = definitions[key];
+
+      if (!value) {
+        throw new Error(
+          `"${key}" was included in route "${fieldName}" but was not found in domain ${fieldName}`,
+        );
+      }
+
+      return [key, value] as const;
+    }),
+  );
+}
+
+interface RouteReference {
+  resources?: Record<string, DomainResource>;
+  integrations?: Record<string, DomainIntegration>;
+}
+
+export function resolveRouteReferences(
+  routes: readonly FlatRoute[],
+  { resources, integrations }: RouteReference,
+) {
+  const resourceKeys = new Set<string>();
+  const integrationKeys = new Set<string>();
+
+  for (const { routeConfig } of routes) {
+    routeConfig.resources?.forEach((v) => resourceKeys.add(v));
+    routeConfig.integrations?.forEach((v) => integrationKeys.add(v));
+  }
+
+  return [
+    resolveKeys(resourceKeys, resources, "resources"),
+    resolveKeys(integrationKeys, integrations, "integrations"),
+  ] as const;
+}
+
+// ----------------------------------------------------------------------------
+// Utility
+// ----------------------------------------------------------------------------
+
+function toHandlerPath(
+  version: string,
+  path: string,
+  method: string,
+  options?: { gateway?: "public" | "private" },
+) {
+  const resolvedPathWithParams = path.slice(1).replace(/:(\w+)/g, "[$1]");
+  const fileExtension = options?.gateway === "private" ? ".private.ts" : ".ts";
+
+  return `handlers/${version}/${resolvedPathWithParams}/${method.toLowerCase()}${fileExtension}`;
+}
+
+export function getFunctionAccess(routeAccess?: string, commonAccess?: string) {
+  return (routeAccess ?? commonAccess ?? "isolated") as RouteAccess;
+}
+
+interface ApiGatewayPathOptions {
+  domain: string;
+  gateway: "public" | "private";
+  version: string;
+  path: string;
+}
+
+export function toApiGatewayPath({
+  domain,
+  gateway,
+  path,
+  version,
+}: ApiGatewayPathOptions) {
+  const resolvedPathWithParams = path.replace(/:(\w+)/g, "{$1}");
+
+  return gateway === "private"
+    ? `${domain}/${version}${resolvedPathWithParams}`
+    : `app/${version}${resolvedPathWithParams}`;
+}
+
+export function toPascalCase(value: string) {
+  return value.replace(/(^|-)(\w)/g, (_, __, character: string) =>
+    character.toUpperCase(),
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,55 @@ importers:
         specifier: 4.0.18
         version: 4.0.18(@types/node@25.2.2)(jiti@2.6.1)(msw@2.12.7(@types/node@25.2.2)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
 
+  domains/poc:
+    dependencies:
+      '@flex/handlers':
+        specifier: workspace:*
+        version: link:../../libs/handlers
+      '@flex/sdk':
+        specifier: workspace:*
+        version: link:../../libs/sdk
+      '@flex/udp-domain':
+        specifier: workspace:*
+        version: link:../udp
+      '@flex/utils':
+        specifier: workspace:*
+        version: link:../../libs/utils
+      http-errors:
+        specifier: 2.0.1
+        version: 2.0.1
+      http-status:
+        specifier: 2.1.0
+        version: 2.1.0
+      zod:
+        specifier: 4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@flex/config':
+        specifier: workspace:*
+        version: link:../../libs/config
+      '@flex/testing':
+        specifier: workspace:*
+        version: link:../../libs/testing
+      '@types/aws-lambda':
+        specifier: 8.10.160
+        version: 8.10.160
+      '@types/http-errors':
+        specifier: 2.0.5
+        version: 2.0.5
+      eslint:
+        specifier: 9.39.2
+        version: 9.39.2(jiti@2.6.1)
+      nock:
+        specifier: 14.0.11
+        version: 14.0.11
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@types/node@25.2.2)(jiti@2.6.1)(msw@2.12.7(@types/node@25.2.2)(typescript@5.9.3))(tsx@4.21.0)(yaml@2.8.2)
+
   domains/udp:
     dependencies:
       '@aws-lambda-powertools/parser':
@@ -405,7 +454,7 @@ importers:
     dependencies:
       '@aws-lambda-powertools/parameters':
         specifier: 2.31.0
-        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.985.0)(@middy/core@7.0.2)
+        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.990.0)(@middy/core@7.0.2)
       '@flex/logging':
         specifier: workspace:*
         version: link:../logging
@@ -437,19 +486,58 @@ importers:
 
   libs/sdk:
     dependencies:
-      aws-cdk-lib:
-        specifier: 2.237.1
-        version: 2.237.1(constructs@10.4.5)
+      '@flex/flex-fetch':
+        specifier: workspace:*
+        version: link:../flex-fetch
+      '@flex/logging':
+        specifier: workspace:*
+        version: link:../logging
+      '@flex/utils':
+        specifier: workspace:*
+        version: link:../utils
+      '@middy/core':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@middy/http-error-handler':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@middy/http-header-normalizer':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@middy/http-json-body-parser':
+        specifier: 7.0.2
+        version: 7.0.2
+      '@middy/secrets-manager':
+        specifier: 7.0.2
+        version: 7.0.2(@aws-sdk/client-secrets-manager@3.985.0)
+      '@middy/ssm':
+        specifier: 7.0.2
+        version: 7.0.2(@aws-sdk/client-ssm@3.990.0)
       zod:
         specifier: 4.3.6
         version: 4.3.6
     devDependencies:
+      '@aws-sdk/client-ssm':
+        specifier: 3.990.0
+        version: 3.990.0
       '@flex/config':
         specifier: workspace:*
         version: link:../config
+      '@flex/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@types/aws-lambda':
+        specifier: 8.10.160
+        version: 8.10.160
+      '@types/http-errors':
+        specifier: 2.0.5
+        version: 2.0.5
       eslint:
         specifier: 9.39.2
         version: 9.39.2(jiti@2.6.1)
+      http-errors:
+        specifier: 2.0.1
+        version: 2.0.1
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -461,7 +549,7 @@ importers:
     devDependencies:
       '@aws-lambda-powertools/parameters':
         specifier: 2.31.0
-        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.985.0)(@middy/core@7.0.2)
+        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.990.0)(@middy/core@7.0.2)
       '@aws-sdk/client-secrets-manager':
         specifier: 3.985.0
         version: 3.985.0
@@ -622,7 +710,7 @@ importers:
     dependencies:
       '@aws-lambda-powertools/parameters':
         specifier: 2.31.0
-        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.985.0)(@middy/core@7.0.2)
+        version: 2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.990.0)(@middy/core@7.0.2)
       '@flex/flex-fetch':
         specifier: workspace:*
         version: link:../../../libs/flex-fetch
@@ -940,6 +1028,10 @@ packages:
 
   '@aws-sdk/client-ssm@3.985.0':
     resolution: {integrity: sha512-7x0TBtdO20yoWHYhWywBUDRrNR1qz6yzizaXbXcPI2gh3kxM4Bl781URGPAaBiGz699eqcZ0pK+TQ9HjyOLpqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-ssm@3.990.0':
+    resolution: {integrity: sha512-SQFrsCsYqgpY6HyeUGfNPepFi0CBTuJri8t9+x3Cvs5zl425XfbdfQtbQi+ecbNO8QICMD45hkBO/iP3wATSpA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-sso@3.985.0':
@@ -1381,8 +1473,8 @@ packages:
     resolution: {integrity: sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/css-tree@3.6.9':
-    resolution: {integrity: sha512-3D5/OHibNEGk+wKwNwMbz63NMf367EoR4mVNNpxddCHKEb2Nez7z62J2U6YjtErSsZDoY0CsccmoUpdEbkogNA==}
+  '@eslint/css-tree@3.6.8':
+    resolution: {integrity: sha512-s0f40zY7dlMp8i0Jf0u6l/aSswS0WRAgkhgETgiCJRcxIWb4S/Sp9uScKHWbkM3BnoFLbJbmOYk5AZUDFVxaLA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   '@eslint/eslintrc@3.3.3':
@@ -1670,6 +1762,15 @@ packages:
       '@aws-sdk/client-secrets-manager': ^3.0.0
     peerDependenciesMeta:
       '@aws-sdk/client-secrets-manager':
+        optional: true
+
+  '@middy/ssm@7.0.2':
+    resolution: {integrity: sha512-5JXnXTNm5Kg1iBtnftZVNz4SSDD5j47jyDkzXWD1BUt+2QjmHWGaRftNlvuhzQV2zsaioog4atOxo5ZVCXfVWQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@aws-sdk/client-ssm': ^3.0.0
+    peerDependenciesMeta:
+      '@aws-sdk/client-ssm':
         optional: true
 
   '@middy/util@7.0.2':
@@ -4766,6 +4867,14 @@ snapshots:
       '@aws-sdk/client-ssm': 3.985.0
       '@middy/core': 7.0.2
 
+  '@aws-lambda-powertools/parameters@2.31.0(@aws-sdk/client-secrets-manager@3.985.0)(@aws-sdk/client-ssm@3.990.0)(@middy/core@7.0.2)':
+    dependencies:
+      '@aws-lambda-powertools/commons': 2.31.0
+    optionalDependencies:
+      '@aws-sdk/client-secrets-manager': 3.985.0
+      '@aws-sdk/client-ssm': 3.990.0
+      '@middy/core': 7.0.2
+
   '@aws-lambda-powertools/parser@2.31.0(@middy/core@7.0.2)(zod@4.3.6)':
     dependencies:
       '@aws-lambda-powertools/commons': 2.31.0
@@ -4828,33 +4937,33 @@ snapshots:
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.10
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.980.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@aws-sdk/util-user-agent-node': 3.972.8
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.13
-      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.9
+      '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
+      '@smithy/smithy-client': 4.11.3
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.29
-      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -4996,41 +5105,86 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso@3.985.0':
+  '@aws-sdk/client-ssm@3.990.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/core': 3.973.10
+      '@aws-sdk/credential-provider-node': 3.972.9
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.10
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/types': 3.973.1
-      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-endpoints': 3.990.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@aws-sdk/util-user-agent-node': 3.972.8
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.1
+      '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.13
-      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.9
+      '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
+      '@smithy/smithy-client': 4.11.3
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.29
-      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.8
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.985.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.10
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.10
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.985.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.8
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -5206,7 +5360,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.5':
     dependencies:
-      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/core': 3.973.10
       '@aws-sdk/nested-clients': 3.985.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
@@ -5402,37 +5556,37 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/core': 3.973.10
       '@aws-sdk/middleware-host-header': 3.972.3
       '@aws-sdk/middleware-logger': 3.972.3
       '@aws-sdk/middleware-recursion-detection': 3.972.3
-      '@aws-sdk/middleware-user-agent': 3.972.7
+      '@aws-sdk/middleware-user-agent': 3.972.10
       '@aws-sdk/region-config-resolver': 3.972.3
       '@aws-sdk/types': 3.973.1
       '@aws-sdk/util-endpoints': 3.985.0
       '@aws-sdk/util-user-agent-browser': 3.972.3
-      '@aws-sdk/util-user-agent-node': 3.972.5
+      '@aws-sdk/util-user-agent-node': 3.972.8
       '@smithy/config-resolver': 4.4.6
-      '@smithy/core': 3.22.1
+      '@smithy/core': 3.23.0
       '@smithy/fetch-http-handler': 5.3.9
       '@smithy/hash-node': 4.2.8
       '@smithy/invalid-dependency': 4.2.8
       '@smithy/middleware-content-length': 4.2.8
-      '@smithy/middleware-endpoint': 4.4.13
-      '@smithy/middleware-retry': 4.4.30
+      '@smithy/middleware-endpoint': 4.4.14
+      '@smithy/middleware-retry': 4.4.31
       '@smithy/middleware-serde': 4.2.9
       '@smithy/middleware-stack': 4.2.8
       '@smithy/node-config-provider': 4.3.8
-      '@smithy/node-http-handler': 4.4.9
+      '@smithy/node-http-handler': 4.4.10
       '@smithy/protocol-http': 5.3.8
-      '@smithy/smithy-client': 4.11.2
+      '@smithy/smithy-client': 4.11.3
       '@smithy/types': 4.12.0
       '@smithy/url-parser': 4.2.8
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
       '@smithy/util-body-length-node': 4.2.1
-      '@smithy/util-defaults-mode-browser': 4.3.29
-      '@smithy/util-defaults-mode-node': 4.2.32
+      '@smithy/util-defaults-mode-browser': 4.3.30
+      '@smithy/util-defaults-mode-node': 4.2.33
       '@smithy/util-endpoints': 3.2.8
       '@smithy/util-middleware': 4.2.8
       '@smithy/util-retry': 4.2.8
@@ -5494,7 +5648,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.985.0':
     dependencies:
-      '@aws-sdk/core': 3.973.7
+      '@aws-sdk/core': 3.973.10
       '@aws-sdk/nested-clients': 3.985.0
       '@aws-sdk/types': 3.973.1
       '@smithy/property-provider': 4.2.8
@@ -5800,7 +5954,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/css-tree@3.6.9':
+  '@eslint/css-tree@3.6.8':
     dependencies:
       mdn-data: 2.23.0
       source-map-js: 1.2.1
@@ -5869,7 +6023,7 @@ snapshots:
 
   '@html-eslint/parser@0.55.0(jiti@2.6.1)':
     dependencies:
-      '@eslint/css-tree': 3.6.9
+      '@eslint/css-tree': 3.6.8
       '@html-eslint/template-syntax-parser': 0.55.0(jiti@2.6.1)
       '@html-eslint/types': 0.55.0(jiti@2.6.1)
       css-tree: 3.1.0
@@ -6153,6 +6307,12 @@ snapshots:
       '@middy/util': 7.0.2
     optionalDependencies:
       '@aws-sdk/client-secrets-manager': 3.985.0
+
+  '@middy/ssm@7.0.2(@aws-sdk/client-ssm@3.990.0)':
+    dependencies:
+      '@middy/util': 7.0.2
+    optionalDependencies:
+      '@aws-sdk/client-ssm': 3.990.0
 
   '@middy/util@7.0.2': {}
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "tsc": "tsc --noEmit",
     "lint": "eslint --max-warnings=0 .",
-    "test:e2e": "vitest run"
+    "test:e2e": "vitest --passWithNoTests"
   },
   "dependencies": {
     "@flex/handlers": "workspace:*",


### PR DESCRIPTION
# Pull Request

## Description

- Config-first approach for defining domains, versioning and routes
  - Per-route context derived from domain-level resources and route configuration
  - Add `routeContext` utility to access context scoped to each route within execution context
- Provision PoC stack alongside hello/udp (temporary solution for comparison)
- Add `poc` domain with examples for each route type
- Separate SDK/CDK type definitions/schemas to use across domains and IaC

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-174

NOTE:

Complete test coverage and documentation to be implemented next:

- Testing: https://gdsgovukagents.atlassian.net/browse/FLEX-211
- Documentation: https://gdsgovukagents.atlassian.net/browse/FLEX-212

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [x] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined
