### PR TITLE
fix: use caller-based permissions and deny all private gateway unless…

### DIFF
--- a/domains/hello/domain.config.ts
+++ b/domains/hello/domain.config.ts
@@ -27,6 +27,10 @@ export const endpoints = defineDomain({
           GET: {
             entry: "handlers/v1/hello-call-internal/get.ts",
             type: "ISOLATED",
+            envEphemeral: {
+              FLEX_PRIVATE_GATEWAY_URL_PARAM_NAME:
+                "/flex/apigw/private/gateway-url",
+            },
           },
         },
       },

--- a/domains/hello/domain.private.config.ts
+++ b/domains/hello/domain.private.config.ts
@@ -9,6 +9,7 @@ export const endpoints = defineDomain({
           GET: {
             type: "ISOLATED",
             entry: "handlers/v1/hello-internal/get.ts",
+            permissions: [],
           },
         },
       },

--- a/domains/udp/domain.config.ts
+++ b/domains/udp/domain.config.ts
@@ -80,10 +80,10 @@ export const endpoints = defineDomain({
             timeoutSeconds: 20,
             permissions: [
               {
-                type: "domain",
+                type: "gateway",
                 target: "udp",
                 path: "/v1/notifications",
-                method: "PATCH",
+                method: "POST",
               },
             ],
           },

--- a/domains/udp/domain.config.ts
+++ b/domains/udp/domain.config.ts
@@ -17,7 +17,8 @@ export const endpoints = defineDomain({
             permissions: [
               {
                 type: "gateway",
-                path: "",
+                target: "udp",
+                path: "/v1/identity/*",
                 method: "POST",
               },
             ],
@@ -42,18 +43,21 @@ export const endpoints = defineDomain({
             permissions: [
               {
                 type: "domain",
-                path: "/v1/notifications",
+                target: "udp",
+                path: "/v1/users",
                 method: "POST",
               },
               {
-                type: "domain",
+                type: "gateway",
+                target: "udp",
                 path: "/v1/notifications",
                 method: "GET",
               },
               {
                 type: "gateway",
-                path: "",
-                method: "GET",
+                target: "udp",
+                path: "/v1/notifications",
+                method: "POST",
               },
             ],
           },
@@ -77,6 +81,7 @@ export const endpoints = defineDomain({
             permissions: [
               {
                 type: "domain",
+                target: "udp",
                 path: "/v1/notifications",
                 method: "PATCH",
               },

--- a/domains/udp/domain.private.config.ts
+++ b/domains/udp/domain.private.config.ts
@@ -17,7 +17,8 @@ export const endpoints = defineDomain({
             permissions: [
               {
                 type: "gateway",
-                path: "user",
+                target: "udp",
+                path: "/v1/users",
                 method: "POST",
               },
             ],

--- a/libs/sdk/src/domain.ts
+++ b/libs/sdk/src/domain.ts
@@ -34,7 +34,7 @@ const permissionsSchema = z.object({
   type: z.enum(["domain", "gateway"]),
   path: z.string(),
   method: z.string(),
-  // TODO: intra-domain permissions
+  target: z.string(),
 });
 
 export type Permission = z.infer<typeof permissionsSchema>;

--- a/platform/domains/udp/src/handlers/service-gateway.ts
+++ b/platform/domains/udp/src/handlers/service-gateway.ts
@@ -12,7 +12,7 @@ import { getConsumerConfig } from "../utils/getConsumerConfig";
 
 const configSchema = z.object({
   AWS_REGION: z.string().min(1),
-  FLEX_UDP_CONSUMER_CONFIG_SECRET_ARN_PARAM_NAME: z.string().min(1),
+  FLEX_UDP_CONSUMER_CONFIG_SECRET_ARN: z.string().min(1),
 });
 
 /**

--- a/platform/infra/flex/src/stacks/legacy-domain.ts
+++ b/platform/infra/flex/src/stacks/legacy-domain.ts
@@ -97,7 +97,11 @@ export class FlexLegacyDomainStack extends BaseStack {
     const publicRestApi = this.#getPublicRestApi();
     const privateRestApi = this.#getPrivateRestApi();
 
-    this.#processPublicRoutes(props.publicDomain, publicRestApi.rootResource);
+    this.#processPublicRoutes(
+      props.publicDomain,
+      publicRestApi.rootResource,
+      privateRestApi.restApi,
+    );
 
     if (props.privateDomain) {
       this.#processPrivateRoutes(
@@ -110,7 +114,11 @@ export class FlexLegacyDomainStack extends BaseStack {
     }
   }
 
-  #processPublicRoutes(domainConfig: IDomain, apiRoot: IResource): void {
+  #processPublicRoutes(
+    domainConfig: IDomain,
+    apiRoot: IResource,
+    internalApiForPermissions?: IRestApi | RestApi,
+  ): void {
     const authorizerFnArn = this.import(STAGE_KEYS.ApigwPublicAuthorizerFn);
 
     const authorizerFn = Function.fromFunctionAttributes(this, "AuthorizerFn", {
@@ -165,6 +173,19 @@ export class FlexLegacyDomainStack extends BaseStack {
           );
 
           this.publicRouteBindings.push({ method, path: newPath });
+
+          if (
+            routeConfig.permissions &&
+            domainEndpointFn.function.role &&
+            internalApiForPermissions
+          ) {
+            this.#grantInternalGatewayPermissions(
+              domainEndpointFn.function.role,
+              routeConfig.permissions,
+              domainConfig.domain,
+              internalApiForPermissions,
+            );
+          }
         }
       }
     }
@@ -432,8 +453,8 @@ export class FlexLegacyDomainStack extends BaseStack {
     const allowedRoutePrefixes = permissions.map((perm) => {
       const base =
         perm.type === "domain"
-          ? `/domains/${domainName}`
-          : `/gateways/${domainName}`;
+          ? `/domains/${perm.target}`
+          : `/gateways/${perm.target}`;
       const suffix = perm.path.startsWith("/") ? perm.path : `/${perm.path}`;
       return `${base}${suffix}`;
     });

--- a/platform/infra/flex/src/stacks/legacy-domain.ts
+++ b/platform/infra/flex/src/stacks/legacy-domain.ts
@@ -23,7 +23,7 @@ import { ENV_KEYS, STAGE_KEYS } from "../ssm-keys";
 import { applyCheckovSkip } from "../utils/applyCheckovSkip";
 import { createHash } from "../utils/create-hash";
 import { getDomainEntry } from "../utils/getEntry";
-import { getParamName } from "../utils/getParamName";
+import { getParamName, getStageParamName } from "../utils/getParamName";
 import { grantPrivateApiAccess } from "../utils/grantPrivateApiAccess";
 
 export interface RouteBinding {
@@ -393,7 +393,7 @@ export class FlexLegacyDomainStack extends BaseStack {
       resource = StringParameter.fromStringParameterName(
         this,
         `EphemeralParam${createHash(path)}`,
-        getParamName(path),
+        getStageParamName(path),
       );
     } else {
       resource = StringParameter.fromStringParameterName(

--- a/platform/infra/flex/src/stacks/platform.ts
+++ b/platform/infra/flex/src/stacks/platform.ts
@@ -211,17 +211,10 @@ export class FlexPlatformStack extends BaseStack {
         "Private API Gateway - Internal service-to-service and domain-to-gateway routing",
       policy: new PolicyDocument({
         statements: [
-          new PolicyStatement({
-            effect: Effect.ALLOW,
-            principals: [new AnyPrincipal()],
-            actions: ["execute-api:Invoke"],
-            resources: ["execute-api:/*"],
-            conditions: {
-              StringEquals: {
-                "aws:SourceVpce": apiGatewayEndpoint.vpcEndpointId,
-              },
-            },
-          }),
+          // Deny everything that doesn't arrive through the VPC interface endpoint.
+          // No explicit Allow is present — for same-account principals this means
+          // the IAM policy becomes the sole gate. Callers must have
+          // execute-api:Invoke on the specific route ARN in their IAM role.
           new PolicyStatement({
             effect: Effect.DENY,
             principals: [new AnyPrincipal()],

--- a/platform/infra/flex/src/utils/createPrivateGatewayRoute.ts
+++ b/platform/infra/flex/src/utils/createPrivateGatewayRoute.ts
@@ -1,5 +1,8 @@
 import type { IResource } from "aws-cdk-lib/aws-apigateway";
-import { LambdaIntegration } from "aws-cdk-lib/aws-apigateway";
+import {
+  AuthorizationType,
+  LambdaIntegration,
+} from "aws-cdk-lib/aws-apigateway";
 import type { IFunction } from "aws-cdk-lib/aws-lambda";
 
 export function createPrivateGatewayRoute(
@@ -14,5 +17,7 @@ export function createPrivateGatewayRoute(
       parent.getResource(segment) ?? parent.addResource(segment),
     gatewayResource,
   );
-  return resource.addMethod(method, new LambdaIntegration(handler));
+  return resource.addMethod(method, new LambdaIntegration(handler), {
+    authorizationType: AuthorizationType.IAM,
+  });
 }

--- a/platform/infra/flex/src/utils/getParamName.ts
+++ b/platform/infra/flex/src/utils/getParamName.ts
@@ -5,3 +5,7 @@ const envConfig = getEnvConfig();
 export function getParamName(name: string) {
   return `/${envConfig.env}${name}`;
 }
+
+export function getStageParamName(name: string) {
+  return `/${envConfig.stage}${name}`;
+}

--- a/platform/infra/flex/src/utils/grantPrivateApiAccess.ts
+++ b/platform/infra/flex/src/utils/grantPrivateApiAccess.ts
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+
 import { IRestApi, RestApi } from "aws-cdk-lib/aws-apigateway";
 import { Effect, IRole, PolicyStatement } from "aws-cdk-lib/aws-iam";
 
@@ -12,6 +14,7 @@ interface RoutePermissions {
 
   /**
    * Route prefixes this domain is allowed to call.
+   * An empty array means this Lambda makes no outbound private API calls — no IAM grant is added.
    *
    * Examples:
    * - ["/gateways/dvla/*"] - Can call DVLA gateway
@@ -54,31 +57,31 @@ export function grantPrivateApiAccess(
   }
 
   if (permissions.allowedRoutePrefixes.length === 0) {
-    throw new Error(
-      `grantPrivateApiAccess: domain "${permissions.domainId}" must specify at least one allowedRoutePrefix. ` +
-        `Use ["/*"] explicitly if you intend to allow all routes.`,
-    );
+    return; // No outbound private API calls needed — nothing to grant.
   }
 
   const methods = permissions.allowedMethods ?? ["*"];
-  const resources = permissions.allowedRoutePrefixes.map((prefix) =>
-    api.arnForExecuteApi("*", prefix, "*"),
+
+  // Build one ARN per (method, prefix) pair so the method is encoded directly
+  // in the resource ARN rather than relying on a condition.
+  const resources = methods.flatMap((method) =>
+    permissions.allowedRoutePrefixes.map((prefix) =>
+      api.arnForExecuteApi(method, prefix, "*"),
+    ),
   );
+
+  const hash = crypto
+    .createHash("md5")
+    .update(resources.join("|"))
+    .digest("hex")
+    .slice(0, 8);
 
   role.addToPrincipalPolicy(
     new PolicyStatement({
-      sid: `AllowPrivateApiAccess${permissions.domainId}`,
+      sid: `AllowPrivateApiAccess${permissions.domainId}${hash}`,
       effect: Effect.ALLOW,
       actions: ["execute-api:Invoke"],
       resources,
-      conditions:
-        methods.length > 0 && !methods.includes("*")
-          ? {
-              StringEquals: {
-                "execute-api:Method": methods,
-              },
-            }
-          : undefined,
     }),
   );
 }

--- a/platform/infra/flex/src/utils/resources.ts
+++ b/platform/infra/flex/src/utils/resources.ts
@@ -7,7 +7,7 @@ import { StringParameter } from "aws-cdk-lib/aws-ssm";
 import type { Construct } from "constructs";
 
 import { createHash } from "./create-hash";
-import { getParamName } from "./getParamName";
+import { getParamName, getStageParamName } from "./getParamName";
 
 export type ImportedResource =
   | { readonly type: "secret"; readonly construct: ISecret }
@@ -63,7 +63,7 @@ function importResource(
         type: "secret",
         construct: importFlexSecret(
           scope,
-          isStageScoped ? getParamName(path) : path,
+          isStageScoped ? getStageParamName(path) : path,
         ),
       };
     case "ssm":
@@ -74,7 +74,7 @@ function importResource(
           ? StringParameter.fromStringParameterName(
               scope,
               `EphemeralParam${createHash(path)}`,
-              getParamName(path),
+              getStageParamName(path),
             )
           : importFlexParameter(scope, path),
       };

--- a/tests/e2e/src/platform/auth.test.ts
+++ b/tests/e2e/src/platform/auth.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, inject } from "vitest";
 
 describe("authentication", () => {
   const { JWT } = inject("e2eEnv");
-  const endpoint = `/v1/hello-public`;
+  const endpoint = `/hello/v1/hello-public`;
 
   describe("CloudFront viewer-request", () => {
     it("rejects request where authorization header is missing", async ({

--- a/tests/e2e/src/platform/private-gateway.test.ts
+++ b/tests/e2e/src/platform/private-gateway.test.ts
@@ -31,17 +31,23 @@ describe("private gateway", () => {
     );
   });
 
-  it.todo(
-    "rejects service-to-service call when route permissions are missing",
-    async ({ cloudfront }) => {
-      const response = await cloudfront.client.get("/v1/hello-call-internal", {
+  it("rejects service-to-service call when route permissions are missing", async ({
+    cloudfront,
+  }) => {
+    const response = await cloudfront.client.get(
+      "/hello/v1/hello-call-internal",
+      {
         headers: { Authorization: `Bearer ${JWT.VALID}` },
-      });
+      },
+    );
 
-      expect(response.status).toBe(403);
-      expect(response.body).toMatchObject({
-        type: "auth_error",
-      });
-    },
-  );
+    // The raw AWS denial message is surfaced intentionally to demonstrate
+    // IAM auth enforcement at the method level.
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject(
+      expect.objectContaining({
+        Message: expect.any(String) as string,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

Enforces IAM-based permissions on the private flex gateway so that only Lambda functions with explicit `execute-api:Invoke` grants can call internal routes. Previously, the resource policy had a broad ALLOW for all VPC endpoint traffic — any Lambda inside the VPC could call any route. This replaces that with a DENY-only resource policy (blocking non-VPC traffic) and delegates per-route access control to caller IAM roles.

Also fixes two bugs:

  1. `#processPublicRoutes` was silently ignoring the `permissions` field
     on route configs — only private routes were granted IAM access to the
     private gateway. Public Lambdas with outbound private API calls
     received 403.

  2. `envEphemeral` SSM paths were resolved using the environment prefix
     (`/development/...`) instead of the stage prefix (`/pr-123/...`),
     causing CloudFormation validation to fail on PR deployments.

[FLEX-205](https://gdsgovukagents.atlassian.net/browse/FLEX-205)

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [x] Manual testing (include instructions below)

Deployed to a PR environment. Verified via e2e test that `hello-call-internal` (an ISOLATED Lambda with no permissions) receives a 403 from the private gateway, confirming IAM denial is working at the method level. Previously this test was .todo and the Lambda returned 500.                                                                      

## Checklist

- [x ] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have performed a self-review of my code

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

Resource policy change (`platform.ts`): The ALLOW statement has been removed. For same-account callers the effective rule is: traffic must arrive via the VPC endpoint AND the caller's  IAM role must have execute-api:Invoke on the specific route ARN. The DENY blocks anything arriving outside the VPC endpoint.

SID uniqueness (`grantPrivateApiAccess.ts`): The previous implementation used a fixed SID (`AllowPrivateApiAccess<domain>`), which caused AWS to reject the inline policy when the same domain had multiple routes each triggering a grant. An MD5 hash of the granted resource ARNs is now appended to the SID.
                                                                                                                                                                                         
`getStageParamName` (`getParamName.ts`): getParamName uses the environment prefix (`/${env}/...`) — correct for shared infrastructure. Stage-scoped resources like the private gateway URL need `/${stage}/.... envEphemeral` entries in legacy domain configs now resolve through `getStageParamName`.