### PR TITLE
Fix: set IAM authorization type private gateway domains

### DIFF
--- a/platform/infra/flex/src/stacks/domain.ts
+++ b/platform/infra/flex/src/stacks/domain.ts
@@ -1,5 +1,6 @@
 import { IacDomainConfig, RouteAccess } from "@flex/sdk";
 import {
+  AuthorizationType,
   IdentitySource,
   IResource,
   LambdaIntegration,
@@ -157,7 +158,9 @@ export class FlexDomainStack extends BaseStack {
           const resource = this.#addDeepResource(
             privateDomainsRoot,
             resourcePath,
-          ).addMethod(method, new LambdaIntegration(lambda.function));
+          ).addMethod(method, new LambdaIntegration(lambda.function), {
+            authorizationType: AuthorizationType.IAM,
+          });
 
           applyCheckovSkip(
             resource,

--- a/platform/infra/flex/src/stacks/legacy-domain.ts
+++ b/platform/infra/flex/src/stacks/legacy-domain.ts
@@ -2,6 +2,7 @@ import { IDomain, IDomainEndpoint, Permission } from "@flex/sdk";
 import { Duration } from "aws-cdk-lib";
 import type { IResource, IRestApi } from "aws-cdk-lib/aws-apigateway";
 import {
+  AuthorizationType,
   IdentitySource,
   LambdaIntegration,
   Resource,
@@ -236,6 +237,7 @@ export class FlexLegacyDomainStack extends BaseStack {
           const resource = this.#addDeepResource(apiRoot, newPath).addMethod(
             method,
             new LambdaIntegration(domainEndpointFn.function),
+            { authorizationType: AuthorizationType.IAM },
           );
 
           applyCheckovSkip(


### PR DESCRIPTION
# Pull Request

## Description

Fixes a misconfiguration where private API Gateway routes added under the `domains` resource were deployed with **Authorization: NONE** instead of `AWS_IAM`.

**Root cause:** `domain.ts` and `legacy-domain.ts` both import the private `RestApi` using `RestApi.fromRestApiAttributes()`. This creates an imported construct that does **not** inherit `defaultMethodOptions` from the original `RestApi` defined in the platform stack. As a result, any `addMethod` call without an explicit `authorizationType` silently defaulted to `NONE` rather than `IAM`. 

The `defaultMethodOptions: { authorizationType: AuthorizationType.IAM }` on the platform `RestApi` construct only applies when methods are added directly in the same CDK stack — not via imported resources in downstream stacks.

Both domain stacks now explicitly pass `{ authorizationType: AuthorizationType.IAM }` on every private route `addMethod` call.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

**Manual test:**
1. Deploy the platform and a domain stack to a development environment
2. In the AWS Console, navigate to API Gateway → PrivateGateway → Resources
3. Select any route under `/domains/` → Method Request
4. Confirm **Authorization** shows `AWS_IAM` (previously showed `NONE`)
5. Attempt to invoke the endpoint without SigV4 signing — expect a `403 Forbidden`
6. Invoke with a correctly signed request from an IAM principal with `execute-api:Invoke` — expect a `200`

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

The resource policy DENY (restricting access to the VPC endpoint) was masking this issue — non-VPC traffic was rejected at the policy level regardless of method authorization, giving the appearance that IAM was being enforced when it was not at the method level. Callers arriving via the VPC endpoint but without valid IAM credentials would have been permitted through.
