### PR TITLE
feat(api): set minimum tls version for public api and cloudfront

### DIFF
--- a/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
+++ b/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
@@ -10,6 +10,7 @@ import {
   FunctionEventType,
   OriginRequestPolicy,
   PriceClass,
+  SecurityPolicyProtocol,
   ViewerProtocolPolicy,
 } from "aws-cdk-lib/aws-cloudfront";
 import { RestApiOrigin } from "aws-cdk-lib/aws-cloudfront-origins";
@@ -201,6 +202,7 @@ export class FlexCloudfront extends Construct {
     this.distribution = new Distribution(this, "Distribution", {
       comment: "Flex Platform CloudFront Distribution for Structural Checks",
       priceClass: PriceClass.PRICE_CLASS_100,
+      minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
       defaultBehavior: {
         origin: new RestApiOrigin(restApi, {
           originPath: "/prod",

--- a/platform/infra/flex/src/stacks/platform.ts
+++ b/platform/infra/flex/src/stacks/platform.ts
@@ -170,6 +170,7 @@ export class FlexPlatformStack extends BaseStack {
     );
 
     const cfnApi = restApi.node.defaultChild as CfnRestApi;
+    cfnApi.endpointAccessMode = "BASIC";
     cfnApi.securityPolicy = "SecurityPolicy_TLS13_1_2_2021_06";
 
     const healthEndpoint = restApi.root

--- a/platform/infra/flex/src/stacks/platform.ts
+++ b/platform/infra/flex/src/stacks/platform.ts
@@ -2,6 +2,7 @@ import { CfnOutput, Duration } from "aws-cdk-lib";
 import {
   AccessLogFormat,
   AuthorizationType,
+  CfnRestApi,
   EndpointType,
   LogGroupLogDestination,
   MethodLoggingLevel,
@@ -167,6 +168,9 @@ export class FlexPlatformStack extends BaseStack {
       "CKV_AWS_120",
       "Disabled for now and will renable when caching strategy is defined",
     );
+
+    const cfnApi = restApi.node.defaultChild as CfnRestApi;
+    cfnApi.securityPolicy = "SecurityPolicy_TLS13_1_2_2021_06";
 
     const healthEndpoint = restApi.root
       .addResource("health")


### PR DESCRIPTION
# Pull Request

## Description

Enforces a minimum TLS 1.2 security policy across the Flex Platform's public-facing infrastructure, addressing a security finding that legacy TLS 1.0/1.1 protocols were permitted.

Two layers are hardened as defence-in-depth:

1. **CloudFront** — sets `minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021` on the distribution, ensuring all viewer (client-to-edge) connections must use TLS 1.2 or higher. Previously, no minimum was explicitly set; when a custom ACM certificate is attached, AWS CloudFront defaults to TLS 1.0.

2. **API Gateway (public REST API)** — sets `endpointAccessMode = "BASIC"` and `securityPolicy = "SecurityPolicy_TLS13_1_2_2021_06"` on the underlying `CfnRestApi`. This provides defence-in-depth: even if CloudFront configuration were to change, the API Gateway itself would reject TLS 1.0/1.1 connections. Escape hatch required since security policy not accessible in construct ([see](https://github.com/aws/aws-cdk/issues/36663)).

**Related Issue:** [FLEX-234](https://gdsgovukagents.atlassian.net/browse/FLEX-234)

## Type of Change

- [x] Other (security hardening — enforcing minimum TLS version)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

**Manual validation steps:**

1. Deploy to staging
2. Confirm TLS 1.0/1.1 connections are rejected at CloudFront:
   ```bash
   curl -v --tls-max 1.1 https://<domain>
   # Expected: TLS handshake failure / connection rejected
   ```
3. Confirm TLS 1.2 connections succeed:
   ```bash
   curl -v --tlsv1.2 https://<staging-domain>/health
   # Expected: 200 OK // or 403 if no token
   ```

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

The `SecurityPolicy_TLS13_1_2_2021_06` policy enforces TLS 1.2 as the minimum, supports TLS 1.3, and uses a modern cipher suite. It requires `endpointAccessMode = "BASIC"` to be set on the `CfnRestApi` — without this, CloudFormation rejects the security policy value.

The private API Gateway is out of scope: it is only reachable via a VPC interface endpoint (no public TLS exposure).
