### PR TITLE
fix(sdk): skip auth extraction for private gateway routes

### DIFF
--- a/domains/udp/src/handlers/v1/users/get.ts
+++ b/domains/udp/src/handlers/v1/users/get.ts
@@ -11,6 +11,7 @@ import createHttpError from "http-errors";
 const context = routeContext<"GET /v1/users">;
 
 export const handler = route("GET /v1/users", async ({ auth, resources }) => {
+  const { logger } = context();
   // TODO: Add to SDK auth or keep alias for this domain only?
   const userId = auth.pairwiseId as UserId;
 
@@ -27,6 +28,8 @@ export const handler = route("GET /v1/users", async ({ auth, resources }) => {
       data: { notificationId, notifications, userId },
     };
   }
+
+  logger.info("No user found creating user");
 
   await createUser(userId, notificationId);
 

--- a/libs/sdk/src/route/build-context.test.ts
+++ b/libs/sdk/src/route/build-context.test.ts
@@ -11,7 +11,7 @@ vi.mock("@flex/logging");
 
 describe("buildHandlerContext", () => {
   const contextOptions: BuildContextOptions = {
-    access: "isolated",
+    gateway: "private",
     logger,
   };
 
@@ -23,7 +23,7 @@ describe("buildHandlerContext", () => {
       const store = buildHandlerContext(
         privateGatewayEventWithAuthorizer.create(),
         context.create(),
-        { ...contextOptions, access: "public" },
+        { ...contextOptions, gateway: "public" },
       );
 
       expect(store.logger).toBe(logger);
@@ -31,39 +31,29 @@ describe("buildHandlerContext", () => {
   });
 
   describe("Auth", () => {
-    it("includes auth in the context when route access is private or isolated (non-public)", ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const isolatedHandlerStore = buildHandlerContext(
-        privateGatewayEventWithAuthorizer.authenticated(),
-        context.create(),
-        contextOptions,
-      );
-
-      expect(isolatedHandlerStore.auth).toStrictEqual({
-        pairwiseId: "test-pairwise-id",
-      });
-
-      const privateHandlerStore = buildHandlerContext(
-        privateGatewayEventWithAuthorizer.authenticated(),
-        context.create(),
-        { ...contextOptions, access: "private" },
-      );
-
-      expect(privateHandlerStore.auth).toStrictEqual({
-        pairwiseId: "test-pairwise-id",
-      });
-    });
-
-    it("omits auth from the context when route access is public", ({
+    it("includes auth in the context when gateway is public", ({
       context,
       privateGatewayEventWithAuthorizer,
     }) => {
       const store = buildHandlerContext(
         privateGatewayEventWithAuthorizer.authenticated(),
         context.create(),
-        { ...contextOptions, access: "public" },
+        { ...contextOptions, gateway: "public" },
+      );
+
+      expect(store.auth).toStrictEqual({
+        pairwiseId: "test-pairwise-id",
+      });
+    });
+
+    it("omits auth from the context when gateway is private", ({
+      context,
+      privateGatewayEventWithAuthorizer,
+    }) => {
+      const store = buildHandlerContext(
+        privateGatewayEventWithAuthorizer.authenticated(),
+        context.create(),
+        { ...contextOptions, gateway: "private" },
       );
 
       expect(store.auth).toBeUndefined();
@@ -77,7 +67,7 @@ describe("buildHandlerContext", () => {
         buildHandlerContext(
           privateGatewayEventWithAuthorizer.unauthenticated(),
           context.create(),
-          contextOptions,
+          { ...contextOptions, gateway: "public" },
         ),
       ).toThrow("Pairwise ID not found");
     });

--- a/libs/sdk/src/route/build-context.ts
+++ b/libs/sdk/src/route/build-context.ts
@@ -6,7 +6,6 @@ import type {
   HeaderConfig,
   LambdaContext,
   LambdaEvent,
-  RouteAccess,
   RouteAuth,
 } from "../types";
 import { RequestBodyParseError } from "../utils/errors";
@@ -15,7 +14,7 @@ import type { ResolvedResource } from "./resolve-config";
 import type { RouteStore } from "./store";
 
 export interface BuildContextOptions {
-  access: RouteAccess;
+  gateway: "public" | "private";
   logger: Logger;
   bodySchema?: ZodType;
   querySchema?: ZodType;
@@ -29,7 +28,7 @@ export function buildHandlerContext(
   event: LambdaEvent,
   context: LambdaContext,
   {
-    access,
+    gateway,
     logger,
     bodySchema,
     querySchema,
@@ -48,10 +47,9 @@ export function buildHandlerContext(
   const resources = resourcesProp
     ? extractResources(context, resourcesProp)
     : undefined;
-
   return {
     logger,
-    ...(access !== "public" && { auth: extractAuth(event.requestContext) }),
+    ...(gateway === "public" && { auth: extractAuth(event.requestContext) }),
     ...(body !== undefined && { body }),
     ...(pathParams && { pathParams }),
     ...(queryParams && { queryParams }),

--- a/libs/sdk/src/route/create-route.test.ts
+++ b/libs/sdk/src/route/create-route.test.ts
@@ -16,7 +16,6 @@ import { mergeHeaders } from "./headers";
 import { buildDomainIntegrations } from "./integrations";
 import { configureMiddleware } from "./middleware";
 import {
-  getRouteAccess,
   getRouteConfig,
   getRouteIntegrations,
   getRouteLogLevel,
@@ -39,7 +38,6 @@ vi.mock("./headers", () => ({ mergeHeaders: vi.fn() }));
 vi.mock("./integrations", () => ({ buildDomainIntegrations: vi.fn() }));
 vi.mock("./middleware", () => ({ configureMiddleware: vi.fn() }));
 vi.mock("./resolve-config", () => ({
-  getRouteAccess: vi.fn(),
   getRouteConfig: vi.fn(),
   getRouteLogLevel: vi.fn(),
   getRouteResources: vi.fn(),
@@ -120,7 +118,6 @@ describe("createRouteHandler", () => {
     } as never);
     vi.mocked(extractRouteKeySegments).mockReturnValue(routeKeySegments);
     vi.mocked(getRouteConfig).mockReturnValue(routeConfig);
-    vi.mocked(getRouteAccess).mockReturnValue("isolated");
     vi.mocked(getRouteLogLevel).mockReturnValue("INFO");
     vi.mocked(buildHandlerContext).mockReturnValue(mockStore);
     vi.mocked(toApiGatewayResponse).mockReturnValue({
@@ -152,20 +149,6 @@ describe("createRouteHandler", () => {
         path: "/test",
         version: "v1",
       });
-    });
-
-    it("resolves access from common and route-level config", () => {
-      vi.mocked(getRouteConfig).mockReturnValue({
-        ...routeConfig,
-        access: "private",
-      });
-
-      registerRoute();
-
-      expect(getRouteAccess).toHaveBeenCalledExactlyOnceWith(
-        "public",
-        "private",
-      );
     });
 
     it("resolves log level from common and route-level config", () => {
@@ -274,7 +257,6 @@ describe("createRouteHandler", () => {
 
   describe("Core Handler", () => {
     it("builds the handler context from the event, context and resolved route config", async () => {
-      vi.mocked(getRouteAccess).mockReturnValue("private");
       vi.mocked(mergeHeaders).mockReturnValue({ test: { name: "x-test" } });
 
       await invokeRoute();
@@ -283,7 +265,7 @@ describe("createRouteHandler", () => {
         mockEvent,
         mockContext,
         expect.objectContaining({
-          access: "private",
+          gateway: "public",
           logger,
           headers: { test: { name: "x-test" } },
         }),

--- a/libs/sdk/src/route/create-route.ts
+++ b/libs/sdk/src/route/create-route.ts
@@ -17,7 +17,6 @@ import { mergeHeaders } from "./headers";
 import { buildDomainIntegrations } from "./integrations";
 import { configureMiddleware } from "./middleware";
 import {
-  getRouteAccess,
   getRouteConfig,
   getRouteFeatureFlags,
   getRouteIntegrations,
@@ -39,7 +38,6 @@ export function createRouteHandler<const Config extends DomainConfig>(
     const routeKeySegments = extractRouteKeySegments(routeKey);
 
     const routeConfig = getRouteConfig(config, routeKeySegments);
-    const access = getRouteAccess(config.common?.access, routeConfig.access);
     const logLevel = getRouteLogLevel(
       config.common?.logLevel,
       routeConfig.logLevel,
@@ -87,7 +85,7 @@ export function createRouteHandler<const Config extends DomainConfig>(
         );
 
         const store = buildHandlerContext(event, context, {
-          access,
+          gateway,
           logger,
           bodySchema,
           querySchema,

--- a/tests/e2e/vitest.config.ts
+++ b/tests/e2e/vitest.config.ts
@@ -6,7 +6,7 @@ export default mergeConfig(
   defineConfig({
     test: {
       globalSetup: "./src/setup.global.ts",
-      testTimeout: 20_000,
+      testTimeout: 30_000,
     },
   }),
 );


### PR DESCRIPTION
# Pull Request

## Description

Fixes a bug where `buildHandlerContext` would attempt to call `extractAuth` for private gateway handlers, which is not possible since private gateway requests do not carry auth context in the request context.

The fix replaces the `access` (a domain-level `RouteAccess` config value) with an explicit `gateway` parameter (`"public" | "private"`) passed directly from the Lambda handler. Auth extraction is now only attempted when the gateway is `"public"`, making the intent explicit and removing the dependency on route-level access config to gate auth behaviour.

A minor addition to `domains/udp/src/handlers/v1/users/get.ts` adds a log line for the "no user found, creating user" path, using the route context logger.

The e2e test timeout has also been bumped from 20s to 30s to allow for a cold start create user journey.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

Manual testing: Delete user records in UDP. Deploy and verify the handler no longer fails attempting to extract auth from the request context.

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_N/A_

## Additional Notes

The key logic change in `build-context.ts`:

```ts
// Before — auth extracted unless access is explicitly "public" (wrong for private gateway)
...(access !== "public" && { auth: extractAuth(event.requestContext) }),

// After — auth only extracted when running behind the public gateway
...(gateway === "public" && { auth: extractAuth(event.requestContext) }),
```

