### PR TITLE
bugfix: DVLA unit test name now matches the expect. Eslint no longer deletes .only calls on tests

### DIFF
--- a/domains/dvla/src/handlers/v1/driving-licence/get.test.ts
+++ b/domains/dvla/src/handlers/v1/driving-licence/get.test.ts
@@ -31,7 +31,14 @@ describe("GET /v1/driving-licence", () => {
       passwordExpiry: "2030-01-01T00:00:00Z", // pragma: allowlist secret
     });
 
-  const mockCustomerSuccess = () =>
+  const mockCustomerSuccess = (
+    products?: {
+      productType: string;
+      productKey: string;
+      productIdentifier: string;
+      dateAdded: string;
+    }[],
+  ) =>
     api
       .get(`/gateways/dvla/v1/customer/${testLinkingId}`)
       .matchHeader("auth", testAuthToken)
@@ -45,7 +52,7 @@ describe("GET /v1/driving-licence", () => {
             lastName: "DOE",
             dateOfBirth: "1990-01-01",
           },
-          products: [
+          products: products ?? [
             {
               productType: "Driving Licence",
               productKey: testProductKey,
@@ -128,22 +135,14 @@ describe("GET /v1/driving-licence", () => {
     }) => {
       mockUdpSuccess();
       mockAuthSuccess();
-
-      api
-        .get(`/gateways/dvla/v1/customer/${testLinkingId}`)
-        .matchHeader("auth", testAuthToken)
-        .reply(200, {
-          customer: {
-            products: [{ productType: "Passport", productKey: "abc" }],
-          },
-        });
+      mockCustomerSuccess([]);
 
       const result = await handler(
         privateGatewayEventWithAuthorizer.create({}),
         context.create(),
       );
 
-      expect(result.statusCode).toBe(502);
+      expect(result.statusCode).toBe(422);
     });
 
     it("returns 502 if licence retrieval fails", async ({

--- a/libs/config/src/eslint.mjs
+++ b/libs/config/src/eslint.mjs
@@ -137,6 +137,7 @@ export const config = [
       ...vitest.configs.recommended.rules,
       "@typescript-eslint/unbound-method": "off",
       "vitest/no-standalone-expect": "off",
+      "vitest/no-focused-tests": ["error", { fixable: false }],
     },
     settings: {
       vitest: { vitestImports: ["@flex/e2e", "@flex/testing"] },


### PR DESCRIPTION
# Pull Request

## Description

updated dval get test so that it expects the right thing and fixed eslint auto deleting .only on tests

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
