### PR TITLE
fix: enforce HTTPS-only access on S3 access log bucket

### DIFF
--- a/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
+++ b/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
@@ -177,6 +177,7 @@ export class FlexCloudfront extends Construct {
     const accessLogBucket = new Bucket(this, "AccessLogBucket", {
       publicReadAccess: false,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
       objectOwnership: ObjectOwnership.OBJECT_WRITER,
       accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
       versioned: true,


### PR DESCRIPTION
Add enforceSSL to the CloudFront access log bucket to deny any requests over plain HTTP via aws:SecureTransport bucket policy.

# Pull Request

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-281

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
