### PR TITLE
fix: Move VPC loopback to a higher rule

### DIFF
--- a/platform/infra/flex/src/stacks/core/vpc.ts
+++ b/platform/infra/flex/src/stacks/core/vpc.ts
@@ -37,9 +37,9 @@ function addInboundDenies90to100(prefix: string, nacl: NetworkAcl) {
   });
 }
 
-function addVpcLoopback190(prefix: string, nacl: NetworkAcl, vpc: Vpc) {
+function addVpcLoopback80(prefix: string, nacl: NetworkAcl, vpc: Vpc) {
   nacl.addEntry(`${prefix}AllowOutboundToVpc`, {
-    ruleNumber: 190,
+    ruleNumber: 80,
     cidr: AclCidr.ipv4(vpc.vpcCidrBlock),
     traffic: AclTraffic.allTraffic(),
     direction: TrafficDirection.EGRESS,
@@ -47,7 +47,7 @@ function addVpcLoopback190(prefix: string, nacl: NetworkAcl, vpc: Vpc) {
   });
 
   nacl.addEntry(`${prefix}AllowInboundFromVpc`, {
-    ruleNumber: 190,
+    ruleNumber: 80,
     cidr: AclCidr.ipv4(vpc.vpcCidrBlock),
     traffic: AclTraffic.allTraffic(),
     direction: TrafficDirection.INGRESS,
@@ -104,8 +104,8 @@ function applyPrivateEgressRules(scope: Construct, vpc: Vpc) {
     subnetSelection: { subnetType: SubnetType.PRIVATE_WITH_EGRESS },
   });
 
+  addVpcLoopback80(prefix, privateEgressNacl, vpc);
   addInboundDenies90to100(prefix, privateEgressNacl);
-  addVpcLoopback190(prefix, privateEgressNacl, vpc);
   allowEphemeralReturn200to300(prefix, privateEgressNacl);
   allowAllOutbound32000(prefix, privateEgressNacl);
 }
@@ -118,8 +118,8 @@ function applyPrivateIsolatedRules(scope: Construct, vpc: Vpc) {
     subnetSelection: { subnetType: SubnetType.PRIVATE_ISOLATED },
   });
 
+  addVpcLoopback80(prefix, privateIsolatedNacl, vpc);
   addInboundDenies90to100(prefix, privateIsolatedNacl);
-  addVpcLoopback190(prefix, privateIsolatedNacl, vpc);
 }
 
 export function createVpc(scope: Construct) {


### PR DESCRIPTION
# Pull Request

## Description

Allow VPC loop back on a higher rule to enable https comms internally in the VPC.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-280

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
