### PR TITLE
chore(coverage): test libs/utils and expand sonar coverage exclusions

### DIFF
--- a/libs/utils/src/http/query-params.test.ts
+++ b/libs/utils/src/http/query-params.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { extractQueryParams } from "./query-params";
+
+describe("extractQueryParams", () => {
+  it("returns empty string and empty object for no params", () => {
+    const [str, obj] = extractQueryParams();
+    expect(str).toBe("");
+    expect(obj).toEqual({});
+  });
+
+  it("handles a string value", () => {
+    const [str, obj] = extractQueryParams({ foo: "bar" });
+    expect(str).toBe("foo=bar");
+    expect(obj).toEqual({ foo: "bar" });
+  });
+
+  it("handles a number value", () => {
+    const [str, obj] = extractQueryParams({ page: 2 });
+    expect(str).toBe("page=2");
+    expect(obj).toEqual({ page: "2" });
+  });
+
+  it("handles a boolean value", () => {
+    const [str, obj] = extractQueryParams({ active: true });
+    expect(str).toBe("active=true");
+    expect(obj).toEqual({ active: "true" });
+  });
+
+  it("appends multiple entries for an array value", () => {
+    const [str] = extractQueryParams({ ids: ["a", "b", "c"] });
+    expect(str).toBe("ids=a&ids=b&ids=c");
+  });
+
+  it("handles mixed scalar and array params", () => {
+    const [str] = extractQueryParams({ q: "hello", tags: ["x", "y"] });
+    expect(str).toContain("q=hello");
+    expect(str).toContain("tags=x");
+    expect(str).toContain("tags=y");
+  });
+
+  it("handles an empty params object", () => {
+    const [str, obj] = extractQueryParams({});
+    expect(str).toBe("");
+    expect(obj).toEqual({});
+  });
+});

--- a/libs/utils/src/http/request.test.ts
+++ b/libs/utils/src/http/request.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRequest, parseResponseBody } from "./request";
+
+describe("buildRequest", () => {
+  const url = new URL("https://example.com/api");
+
+  it("sets method and default Content-Type header", () => {
+    const req = buildRequest(url, "GET");
+    expect(req.method).toBe("GET");
+    expect(req.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("merges custom headers with default Content-Type", () => {
+    const req = buildRequest(url, "POST", {
+      headers: { Authorization: "Bearer token" },
+    });
+    expect(req.headers.get("Authorization")).toBe("Bearer token");
+    expect(req.headers.get("Content-Type")).toBe("application/json");
+  });
+
+  it("stringifies body when provided", async () => {
+    const req = buildRequest(url, "POST", { body: { foo: "bar" } });
+    expect(await req.text()).toBe(JSON.stringify({ foo: "bar" }));
+  });
+
+  it("omits body when not provided", async () => {
+    const req = buildRequest(url, "GET");
+    expect(await req.text()).toBe("");
+  });
+
+  it("omits body when null is passed", async () => {
+    const req = buildRequest(url, "DELETE", { body: null });
+    expect(await req.text()).toBe("");
+  });
+});
+
+describe("parseResponseBody", () => {
+  function makeResponse(
+    body: string,
+    status: number,
+    headers: Record<string, string> = {},
+  ) {
+    return new Response(body, { status, headers });
+  }
+
+  it("returns undefined for 204 responses", async () => {
+    const result = await parseResponseBody(new Response(null, { status: 204 }));
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when Content-Length is 0", async () => {
+    const result = await parseResponseBody(
+      makeResponse("", 200, { "Content-Length": "0" }),
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when body text is empty", async () => {
+    const result = await parseResponseBody(makeResponse("", 200));
+    expect(result).toBeUndefined();
+  });
+
+  it("parses JSON body when content-type is application/json", async () => {
+    const result = await parseResponseBody(
+      makeResponse(JSON.stringify({ id: 1 }), 200, {
+        "Content-Type": "application/json",
+      }),
+    );
+    expect(result).toEqual({ id: 1 });
+  });
+
+  it("returns raw text when JSON parsing fails", async () => {
+    const result = await parseResponseBody(
+      makeResponse("not-json{", 200, { "Content-Type": "application/json" }),
+    );
+    expect(result).toBe("not-json{");
+  });
+
+  it("returns raw text for non-JSON content types", async () => {
+    const result = await parseResponseBody(
+      makeResponse("plain text", 200, { "Content-Type": "text/plain" }),
+    );
+    expect(result).toBe("plain text");
+  });
+});

--- a/libs/utils/src/http/url.test.ts
+++ b/libs/utils/src/http/url.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { buildUrl } from "./url";
+
+describe("buildUrl", () => {
+  it("joins baseUrl and path with a leading slash", () => {
+    const url = buildUrl("https://example.com", "/api/v1");
+    expect(url.href).toBe("https://example.com/api/v1");
+  });
+
+  it("joins baseUrl and path without a leading slash", () => {
+    const url = buildUrl("https://example.com/", "api/v1");
+    expect(url.href).toBe("https://example.com/api/v1");
+  });
+
+  it("appends trailing slash to baseUrl when missing", () => {
+    const url = buildUrl("https://example.com", "/resource");
+    expect(url.href).toBe("https://example.com/resource");
+  });
+
+  it("does not double-slash when baseUrl already has trailing slash", () => {
+    const url = buildUrl("https://example.com/", "/resource");
+    expect(url.href).toBe("https://example.com/resource");
+  });
+
+  it("appends query params when provided", () => {
+    const url = buildUrl("https://example.com", "/search", { q: "test" });
+    expect(url.search).toBe("?q=test");
+  });
+
+  it("does not set search when params are not provided", () => {
+    const url = buildUrl("https://example.com", "/search");
+    expect(url.search).toBe("");
+  });
+
+  it("handles array query params", () => {
+    const url = buildUrl("https://example.com", "/items", {
+      ids: ["1", "2"],
+    });
+    expect(url.search).toContain("ids=1");
+    expect(url.search).toContain("ids=2");
+  });
+});

--- a/libs/utils/src/response/json.test.ts
+++ b/libs/utils/src/response/json.test.ts
@@ -1,0 +1,38 @@
+import { APIGatewayProxyStructuredResultV2 } from "aws-lambda";
+import { describe, expect, it } from "vitest";
+
+import { jsonResponse } from "./json";
+
+describe("jsonResponse", () => {
+  it("returns status code, stringified body, and JSON content-type header", () => {
+    const result = jsonResponse(200, { ok: true });
+    expect(result).toEqual({
+      statusCode: 200,
+      body: JSON.stringify({ ok: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
+  it("returns undefined body when no body is provided", () => {
+    const result = jsonResponse(204) as APIGatewayProxyStructuredResultV2;
+    expect(result.body).toBeUndefined();
+  });
+
+  it("always sets Content-Type header", () => {
+    expect(
+      (jsonResponse(500) as APIGatewayProxyStructuredResultV2).headers,
+    ).toEqual({
+      "Content-Type": "application/json",
+    });
+  });
+
+  it("passes through the status code", () => {
+    expect(
+      (
+        jsonResponse(404, {
+          message: "Not Found",
+        }) as APIGatewayProxyStructuredResultV2
+      ).statusCode,
+    ).toBe(404);
+  });
+});

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,7 +13,26 @@ sonar.test.inclusions=**/*.test.ts,**/*.spec.ts,**/__mocks__/**,**/__tests__/**
 # sonar.qualitygate.wait=true
 sonar.typescript.tsconfigPaths=domains/*/tsconfig.json,libs/*/tsconfig.json,platform/**/tsconfig.json,tests/e2e/tsconfig.json
 sonar.exclusions=**/dist/**,**/coverage/**,**/.nx/**,**/cdk.out/**
-sonar.coverage.exclusions=platform/infra/**,libs/cli/**,libs/config/**,libs/testing/**
+# domains/example is a reference implementations for domain authors,
+# not production logic — coverage requirements create maintenance burden with no safety gain.
+#
+# domains/*/domain.config.ts are pure CDK/infra config declarations with no testable logic.
+#
+# platform/domains/*/src/client/** are thin HTTP wiring with no branching logic;
+# behaviour is covered by executor and e2e tests.
+#
+# libs/utils/src/openapi/** and libs/utils/src/schemas/domain/** are OpenAPI doc generation
+# helpers, not production application logic.
+sonar.coverage.exclusions=platform/infra/**,\
+  libs/cli/**,\
+  libs/config/**,\
+  libs/testing/**,\
+  domains/example/**,\
+  domains/local-council/**,\
+  domains/*/domain.config.ts,\
+  platform/domains/*/src/client/**,\
+  libs/utils/src/openapi/**,\
+  libs/utils/src/schemas/domain/**
 
 sonar.javascript.lcov.reportPaths=domains/*/coverage/lcov.info,libs/*/coverage/lcov.info,platform/domains/*/coverage/lcov.info
 


### PR DESCRIPTION
# Pull Request

## Description

-   Add contract tests for extractQueryParams, buildUrl, jsonResponse, buildRequest,
-   and parseResponseBody. Exclude reference domains, domain config files, HTTP client
-   wiring, and OpenAPI helpers from coverage requirements with documented rationale.

**Related Issue:** [FLEX-312](https://gdsgovukagents.atlassian.net/browse/FLEX-312)

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
