### PR TITLE
fix: zap remove sarif failing step (not required)

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -70,13 +70,6 @@ jobs:
               cmd_options: '-a -O ${{ secrets.STAGING_API_URL }} -z "-config format.sarif=true -config report.sarif=report.sarif"' # Options https://github.com/zaproxy/zaproxy/blob/255a7b8e9cc923506a61367f935ae5aa7afdd811/docker/zap-api-scan.py#L87
               allow_issue_writing: false # We don't want to create Github issues for now
 
-        - name: Upload to Security Tab
-          if: always() # Upload even if vulnerabilities are found
-          uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
-          with:
-            sarif_file: 'report.sarif'
-            category: 'owasp-zap'
-
   workflow_fail:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

Removed the sarif step in the zap.yml workflow, because it isn't required and will fail.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-185

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

[Doc to test](https://github.com/govuk-once/flex/blob/main/docs/zap.md) 

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined
