### PR TITLE
test(coverage):

### DIFF
--- a/platform/domains/auth/src/functions/jwks-endpoint.test.ts
+++ b/platform/domains/auth/src/functions/jwks-endpoint.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@aws-lambda-powertools/parameters/secrets");
+vi.mock("@flex/logging");
+
+import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
+
+import { handler } from "./jwks-endpoint";
+
+describe("JWKS Endpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 200 with JWKS when secret is valid", async () => {
+    vi.mocked(getSecret).mockResolvedValue({ n: "test-n-value", kid: "test-kid" } as never);
+
+    const result = await handler();
+
+    expect(result).toEqual({
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        keys: [
+          {
+            alg: "RS256",
+            e: "AQAB",
+            kty: "RSA",
+            n: "test-n-value",
+            use: "sig",
+            kid: "test-kid",
+          },
+        ],
+      }),
+    });
+  });
+
+  it("returns 500 when getSecret throws", async () => {
+    vi.mocked(getSecret).mockRejectedValue(new Error("Secrets Manager error"));
+
+    const result = await handler();
+
+    expect(result).toEqual({
+      statusCode: 500,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Internal Server Error" }),
+    });
+  });
+
+  it("returns 500 when secret fails schema validation", async () => {
+    vi.mocked(getSecret).mockResolvedValue({ unexpected: "shape" } as never);
+
+    const result = await handler();
+
+    expect(result).toEqual({
+      statusCode: 500,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Internal Server Error" }),
+    });
+  });
+});

--- a/platform/domains/auth/src/functions/jwks-endpoint.test.ts
+++ b/platform/domains/auth/src/functions/jwks-endpoint.test.ts
@@ -13,7 +13,10 @@ describe("JWKS Endpoint", () => {
   });
 
   it("returns 200 with JWKS when secret is valid", async () => {
-    vi.mocked(getSecret).mockResolvedValue({ n: "test-n-value", kid: "test-kid" } as never);
+    vi.mocked(getSecret).mockResolvedValue({
+      n: "test-n-value",
+      kid: "test-kid",
+    } as never);
 
     const result = await handler();
 

--- a/platform/domains/uns/src/contract/executor.test.ts
+++ b/platform/domains/uns/src/contract/executor.test.ts
@@ -138,5 +138,61 @@ describe("UNS Executor", () => {
         message: "Missing or invalid externalUserID query parameter",
       });
     });
+
+    it("throws 404 when route is not registered", async ({
+      privateGatewayEvent,
+    }) => {
+      const event = privateGatewayEvent.get("/v1/unknown-route");
+
+      await expect(execute(event, remoteClient)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Route not found",
+      });
+    });
+
+    it("throws 400 when PATCH body is missing", async ({
+      privateGatewayEvent,
+    }) => {
+      const event = privateGatewayEvent.create({
+        httpMethod: "PATCH",
+        path: "/v1/notifications/notif-123/status",
+        queryStringParameters: { externalUserID: "user-123" },
+        body: null,
+      });
+
+      await expect(execute(event, remoteClient)).rejects.toMatchObject({
+        statusCode: 400,
+      });
+    });
+
+    it("throws 400 when PATCH body is invalid JSON", async ({
+      privateGatewayEvent,
+    }) => {
+      const event = privateGatewayEvent.create({
+        httpMethod: "PATCH",
+        path: "/v1/notifications/notif-123/status",
+        queryStringParameters: { externalUserID: "user-123" },
+        body: "not-valid-json{",
+      });
+
+      await expect(execute(event, remoteClient)).rejects.toMatchObject({
+        statusCode: 400,
+      });
+    });
+
+    it("throws 400 when PATCH body fails schema validation", async ({
+      privateGatewayEvent,
+    }) => {
+      const event = privateGatewayEvent.create({
+        httpMethod: "PATCH",
+        path: "/v1/notifications/notif-123/status",
+        queryStringParameters: { externalUserID: "user-123" },
+        body: JSON.stringify({ Status: "INVALID_STATUS" }),
+      });
+
+      await expect(execute(event, remoteClient)).rejects.toMatchObject({
+        statusCode: 400,
+      });
+    });
   });
 });

--- a/platform/domains/uns/src/handlers/service-gateway.test.ts
+++ b/platform/domains/uns/src/handlers/service-gateway.test.ts
@@ -227,7 +227,9 @@ describe("UNS Service Gateway", () => {
   it("returns 500 for unexpected non-HTTP errors", async ({
     privateGatewayEvent,
   }) => {
-    remoteClient.notifications.get.mockRejectedValue(new Error("Unexpected error"));
+    remoteClient.notifications.get.mockRejectedValue(
+      new Error("Unexpected error"),
+    );
 
     const response = await handler(
       privateGatewayEvent.get("/gateways/uns/v1/notifications", {

--- a/platform/domains/uns/src/handlers/service-gateway.test.ts
+++ b/platform/domains/uns/src/handlers/service-gateway.test.ts
@@ -223,4 +223,77 @@ describe("UNS Service Gateway", () => {
       }),
     });
   });
+
+  it("returns 500 for unexpected non-HTTP errors", async ({
+    privateGatewayEvent,
+  }) => {
+    remoteClient.notifications.get.mockRejectedValue(new Error("Unexpected error"));
+
+    const response = await handler(
+      privateGatewayEvent.get("/gateways/uns/v1/notifications", {
+        queryStringParameters: { externalUserID: "user-123" },
+      }),
+      context,
+    );
+
+    expect(response).toEqual({
+      statusCode: 500,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Internal server error" }),
+    });
+  });
+
+  it("passes through 4xx error with body from remote", async ({
+    privateGatewayEvent,
+  }) => {
+    remoteClient.notifications.get.mockResolvedValue({
+      ok: false,
+      error: {
+        status: 400,
+        message: "Bad Request",
+        body: { detail: "invalid externalUserID" },
+      },
+    });
+
+    const response = await handler(
+      privateGatewayEvent.get("/gateways/uns/v1/notifications", {
+        queryStringParameters: { externalUserID: "user-123" },
+      }),
+      context,
+    );
+
+    expect(response).toEqual({
+      statusCode: 400,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "Bad Request",
+        error: { detail: "invalid externalUserID" },
+      }),
+    });
+  });
+
+  it("passes through 4xx error without body from remote", async ({
+    privateGatewayEvent,
+  }) => {
+    remoteClient.notifications.get.mockResolvedValue({
+      ok: false,
+      error: {
+        status: 404,
+        message: "Not Found",
+      },
+    });
+
+    const response = await handler(
+      privateGatewayEvent.get("/gateways/uns/v1/notifications", {
+        queryStringParameters: { externalUserID: "user-123" },
+      }),
+      context,
+    );
+
+    expect(response).toEqual({
+      statusCode: 404,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "Not Found" }),
+    });
+  });
 });

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,6 +30,8 @@ sonar.coverage.exclusions=platform/infra/**,\
   domains/local-council/**,\
   domains/*/domain.config.ts,\
   platform/domains/*/src/client/**,\
+  platform/domains/*/src/utils/**,\
+  domains/uns/src/data/**,\
   libs/utils/src/openapi/**,\
   libs/utils/src/schemas/domain/**,\
   **/schemas/**


### PR DESCRIPTION
add auth jwks-endpoint tests and platform/uns branch coverage

  - Exclude platform/domains/*/src/utils/** and domains/uns/src/data/** from Sonar coverage (thin wiring wrappers and static mock data)
  - Add jwks-endpoint.test.ts for auth — covers success, fetch failure, and schema validation failure paths (0% → 100%)
  - Add missing executor branches: route-not-found, PATCH body-missing, invalid JSON, and validation failure
  - Add service-gateway tests for non-HTTP errors (500) and 4xx remote responses with and without a body

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)
