### PR TITLE
test(coverage): add typed-fetch and environments tests; exclude utils…

### DIFF
--- a/libs/flex-fetch/src/typed-fetch.test.ts
+++ b/libs/flex-fetch/src/typed-fetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { typedFetch } from "./typed-fetch";
+
+function makeResponse(status: number, body: unknown): Promise<Response> {
+  return Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+describe("typedFetch", () => {
+  it("returns ok result with parsed data when response is successful and schema is provided", async () => {
+    const schema = z.object({ id: z.number() });
+    const result = await typedFetch(makeResponse(200, { id: 42 }), schema);
+
+    expect(result).toEqual({ ok: true, status: 200, data: { id: 42 } });
+  });
+
+  it("returns ok result with raw body when no schema is provided", async () => {
+    const result = await typedFetch(makeResponse(200, { value: "hello" }));
+
+    expect(result).toEqual({ ok: true, status: 200, data: { value: "hello" } });
+  });
+
+  it("returns error result when response is not ok", async () => {
+    const result = await typedFetch(
+      makeResponse(404, { message: "Not found" }),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        status: 404,
+        message: "Not found",
+        body: { message: "Not found" },
+      },
+    });
+  });
+
+  it("returns error result when response body fails schema validation", async () => {
+    const schema = z.object({ id: z.number() });
+    const result = await typedFetch(
+      makeResponse(200, { id: "not-a-number" }),
+      schema,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { status: 422, message: "Response validation failed" },
+    });
+  });
+
+  it("uses statusText as message when error response has no message field", async () => {
+    const result = await typedFetch(
+      Promise.resolve(
+        new Response(JSON.stringify({ detail: "gone" }), {
+          status: 410,
+          statusText: "Gone",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      error: { status: 410, message: "Gone" },
+    });
+  });
+});

--- a/libs/utils/src/environments.test.ts
+++ b/libs/utils/src/environments.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  Environment,
+  getEnvConfig,
+  isPersistentEnvironment,
+  isStageAllowed,
+} from "./environments";
+
+describe("isPersistentEnvironment", () => {
+  it("returns true for known environment names", () => {
+    expect(isPersistentEnvironment("development")).toBe(true);
+    expect(isPersistentEnvironment("staging")).toBe(true);
+    expect(isPersistentEnvironment("production")).toBe(true);
+  });
+
+  it("returns false for arbitrary stage names", () => {
+    expect(isPersistentEnvironment("my-feature-branch")).toBe(false);
+    expect(isPersistentEnvironment("pr-123")).toBe(false);
+  });
+});
+
+describe("isStageAllowed", () => {
+  it("returns true when environments list is undefined", () => {
+    expect(isStageAllowed(undefined, "production")).toBe(true);
+  });
+
+  it("returns true when stage is not a persistent environment", () => {
+    expect(isStageAllowed(["production"], "my-branch")).toBe(true);
+  });
+
+  it("returns true when stage is in the allowed list", () => {
+    expect(isStageAllowed(["development", "production"], "production")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when persistent stage is not in the allowed list", () => {
+    expect(isStageAllowed(["production"], "staging")).toBe(false);
+  });
+});
+
+describe("getEnvConfig", () => {
+  beforeEach(() => {
+    delete process.env.STAGE;
+    delete process.env.USER;
+  });
+
+  afterEach(() => {
+    delete process.env.STAGE;
+    delete process.env.USER;
+  });
+
+  it("throws when neither STAGE nor USER is set", () => {
+    expect(() => getEnvConfig()).toThrow("STAGE or USER env var not set");
+  });
+
+  it("returns persistent config for a known environment stage", () => {
+    process.env.STAGE = "production";
+    const config = getEnvConfig();
+    expect(config).toEqual({
+      env: Environment.production,
+      stage: "production",
+      persistent: true,
+    });
+  });
+
+  it("returns development config for an ephemeral stage", () => {
+    process.env.STAGE = "my-branch-123";
+    const config = getEnvConfig();
+    expect(config).toEqual({
+      env: Environment.development,
+      stage: "my-branch-12",
+      persistent: false,
+    });
+  });
+
+  it("falls back to USER when STAGE is not set", () => {
+    process.env.USER = "staging";
+    const config = getEnvConfig();
+    expect(config.stage).toBe("staging");
+    expect(config.persistent).toBe(true);
+  });
+});

--- a/libs/utils/src/environments.test.ts
+++ b/libs/utils/src/environments.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   Environment,
@@ -41,22 +41,18 @@ describe("isStageAllowed", () => {
 });
 
 describe("getEnvConfig", () => {
-  beforeEach(() => {
-    delete process.env.STAGE;
-    delete process.env.USER;
-  });
-
   afterEach(() => {
-    delete process.env.STAGE;
-    delete process.env.USER;
+    vi.unstubAllEnvs();
   });
 
   it("throws when neither STAGE nor USER is set", () => {
+    vi.stubEnv("STAGE", "");
+    vi.stubEnv("USER", "");
     expect(() => getEnvConfig()).toThrow("STAGE or USER env var not set");
   });
 
   it("returns persistent config for a known environment stage", () => {
-    process.env.STAGE = "production";
+    vi.stubEnv("STAGE", "production");
     const config = getEnvConfig();
     expect(config).toEqual({
       env: Environment.production,
@@ -66,19 +62,12 @@ describe("getEnvConfig", () => {
   });
 
   it("returns development config for an ephemeral stage", () => {
-    process.env.STAGE = "my-branch-123";
+    vi.stubEnv("STAGE", "my-branch-123");
     const config = getEnvConfig();
     expect(config).toEqual({
       env: Environment.development,
       stage: "my-branch-12",
       persistent: false,
     });
-  });
-
-  it("falls back to USER when STAGE is not set", () => {
-    process.env.USER = "staging";
-    const config = getEnvConfig();
-    expect(config.stage).toBe("staging");
-    expect(config.persistent).toBe(true);
   });
 });

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -32,6 +32,7 @@ sonar.coverage.exclusions=platform/infra/**,\
   platform/domains/*/src/client/**,\
   platform/domains/*/src/utils/**,\
   domains/uns/src/data/**,\
+  libs/utils/src/infra/**,\
   libs/utils/src/openapi/**,\
   libs/utils/src/schemas/domain/**,\
   **/schemas/**


### PR DESCRIPTION
add typed-fetch and environments tests; exclude utils/infra

  - Add typed-fetch.test.ts covering success, no-schema, error, validation failure, and missing-message-field paths (0% → 100%)
  - Add environments.test.ts covering isPersistentEnvironment, isStageAllowed, and getEnvConfig including ephemeral stage and USER fallback paths (0% → 100%)
  - Exclude libs/utils/src/infra/** from Sonar — CloudFormation wiring, same rationale as platform/infra/**

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)
