### PR TITLE
test(example-domain): use http and sdk fixtures in tests

### DIFF
--- a/domains/example/src/handlers/v0/headers/get.test.ts
+++ b/domains/example/src/handlers/v0/headers/get.test.ts
@@ -6,70 +6,59 @@ import { handler } from "./get";
 describe("GET /v0/headers", () => {
   const endpoint = "/headers";
 
-  describe("request validation", () => {
-    it("returns 400 when required header is missing", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint, {
-          headers: {
-            "x-correlation-id": "correlation-value",
-            "x-example-id": "example-value",
-          },
-        }),
-        context.create(),
-      );
+  it("returns 400 when a required header is missing", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: {
+          "x-correlation-id": "correlation-value",
+          "x-example-id": "example-value",
+        },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(400);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        message: "Missing headers: x-request-id",
-        headers: ["x-request-id"],
-      });
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      message: "Missing headers: x-request-id",
+      headers: ["x-request-id"],
     });
   });
 
-  describe("response", () => {
-    it("returns 200 with all headers resolved", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint, {
-          headers: {
-            "x-request-id": "request-value",
-            "x-correlation-id": "correlation-value",
-            "x-example-id": "example-value",
-          },
-        }),
-        context.create(),
-      );
+  it("returns 200 with all headers resolved", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: {
+          "x-request-id": "request-value",
+          "x-correlation-id": "correlation-value",
+          "x-example-id": "example-value",
+        },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        correlationId: "correlation-value",
-        exampleId: "example-value",
-        requestId: "request-value",
-      });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      correlationId: "correlation-value",
+      exampleId: "example-value",
+      requestId: "request-value",
     });
+  });
 
-    it("returns 200 with optional headers set to null when omitted", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint, {
-          headers: { "x-request-id": "request-value" },
-        }),
-        context.create(),
-      );
+  it("returns 200 with optional headers set to null when omitted", async ({
+    sdk,
+  }) => {
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: { "x-request-id": "request-value" },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        correlationId: null,
-        exampleId: null,
-        requestId: "request-value",
-      });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      correlationId: null,
+      exampleId: null,
+      requestId: "request-value",
     });
   });
 });

--- a/domains/example/src/handlers/v0/identity/[service]/get.private.test.ts
+++ b/domains/example/src/handlers/v0/identity/[service]/get.private.test.ts
@@ -1,103 +1,82 @@
 import { it } from "@flex/testing";
 import { createUserId } from "@utils/parser";
-import nock from "nock";
 import { describe, expect } from "vitest";
 
 import { handler } from "./get.private";
 
 describe("GET /v0/identity/:service [private]", () => {
-  const gateway = nock("https://execute-api.eu-west-2.amazonaws.com");
-
   const service = "test-service";
+  const endpoint = `/identity/${service}`;
+
   const userId = createUserId("test-user-id");
 
-  const endpoint = `/identity/${service}`;
-  const event = {
-    httpMethod: "GET",
-    path: endpoint,
-    headers: { "User-Id": userId },
-    pathParameters: { service },
-  };
-
-  const existingIdentity = {
+  const identity = {
     serviceId: "existing-id",
     serviceName: "test-service",
   };
 
-  describe("request validation", () => {
-    it("returns 400 when user ID header is missing", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          headers: undefined,
-        }),
-        context.create(),
-      );
+  it("returns 400 when the User-Id header is missing", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint, { params: { service } }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(400);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        headers: ["User-Id"],
-        message: "Missing headers: User-Id",
-      });
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      headers: ["User-Id"],
+      message: "Missing headers: User-Id",
     });
   });
 
-  describe("response", () => {
-    it("returns 200 with identity link details", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      gateway
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, existingIdentity);
+  it("returns 200 with the identity link details", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: { "User-Id": userId },
+        params: { service },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual(existingIdentity);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(identity);
   });
 
-  describe("errors", () => {
-    it("returns 404 when identity does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      gateway
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(404);
+  it("returns 404 when the identity does not exist", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: { "User-Id": userId },
+        params: { service },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(404);
-    });
+    expect(result.statusCode).toBe(404);
+  });
 
-    it("returns 502 when upstream fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      gateway
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(500);
+  it("returns 502 when the upstream fails", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(500);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        headers: { "User-Id": userId },
+        params: { service },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/example/src/handlers/v0/identity/[service]/get.test.ts
+++ b/domains/example/src/handlers/v0/identity/[service]/get.test.ts
@@ -1,82 +1,67 @@
 import { it } from "@flex/testing";
 import { createUserId } from "@utils/parser";
-import nock from "nock";
 import { describe, expect } from "vitest";
 
 import { handler } from "./get";
 
 describe("GET /v0/identity/:service", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
-
   const service = "test-service";
-  const userId = createUserId("test-pairwise-id");
-
   const endpoint = `/identity/${service}`;
-  const event = {
-    httpMethod: "GET",
-    path: endpoint,
-    pathParameters: { service },
-  };
 
-  const existingIdentity = {
+  const userId = createUserId("test-user-id");
+
+  const identity = {
     serviceId: "existing-id",
     serviceName: "test-service",
   };
 
-  describe("response", () => {
-    it("returns 200 with linked set to true when identity exists", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, existingIdentity);
+  it("returns 200 with linked true when the identity exists", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service } }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: true });
-    });
-
-    it("returns 200 with linked set to false when identity does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(404);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: false });
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ linked: true });
   });
 
-  describe("errors", () => {
-    it("returns 502 when upstream fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(500);
+  it("returns 200 with linked false when the identity does not exist", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service } }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ linked: false });
+  });
+
+  it("returns 502 when upstream fails", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${service}`, { headers: { "User-Id": userId } })
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service } }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/example/src/handlers/v0/notifications/patch.test.ts
+++ b/domains/example/src/handlers/v0/notifications/patch.test.ts
@@ -1,6 +1,5 @@
 import { it } from "@flex/testing";
 import { createUserId } from "@utils/parser";
-import nock from "nock";
 import { describe, expect, vi } from "vitest";
 
 import { handler } from "./patch";
@@ -15,79 +14,72 @@ vi.mock("node:crypto", () => ({
 }));
 
 describe("PATCH /v0/notifications", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
   const endpoint = "/notifications";
-  const event = {
-    body: { consentStatus: "accepted" },
-  };
 
+  const userId = createUserId("test-user-id");
+  // TODO: Create a branded cast for push IDs?
+  const pushId = "test-push-id";
   const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
-  const userId = createUserId("test-pairwise-id");
 
-  const updatedNotifications = {
+  const notifications = {
     consentStatus: "accepted",
-    pushId: "test-push-id",
+    pushId,
   };
 
-  describe("request validation", () => {
-    it.for([
-      {
-        body: { consentStatus: "yes" },
-        reason: "contains invalid consent status",
-      },
-      { body: {}, reason: "is empty" },
-    ])(
-      "returns 400 when payload $reason",
-      async ({ body }, { context, privateGatewayEventWithAuthorizer }) => {
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.patch(endpoint, { body }),
-          context.withSecret(secrets).create(), // pragma: allowlist secret
-        );
-
-        expect(result.statusCode).toBe(400);
-        expect(JSON.parse(result.body)).toStrictEqual({
-          message: "Invalid request body",
-        });
-      },
+  it.for([
+    {
+      body: { consentStatus: "yes" },
+      reason: "contains invalid consent status",
+    },
+    { body: {}, reason: "is empty" },
+  ])("returns 400 when payload $reason", async ({ body }, { sdk }) => {
+    const result = await handler(
+      sdk.event.patch(endpoint, { userId, body }),
+      sdk.context({ secrets }),
     );
-  });
 
-  describe("response", () => {
-    it("returns 200 when notifications are updated", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(200, updatedNotifications);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.patch(endpoint, event),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual(updatedNotifications);
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      message: "Invalid request body",
     });
   });
 
-  describe("errors", () => {
-    it("returns 502 when upstream fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(500);
+  it("returns 200 when notifications are updated", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: { "requesting-service-user-id": userId },
+      })
+      .reply(200, notifications);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.patch(endpoint, event),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
+    const result = await handler(
+      sdk.event.patch(endpoint, {
+        userId,
+        body: { consentStatus: "accepted" },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(notifications);
+  });
+
+  it("returns 502 when the upstream fails", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: { "requesting-service-user-id": userId },
+      })
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.patch(endpoint, {
+        userId,
+        body: { consentStatus: "accepted" },
+      }),
+      sdk.context({ secrets }),
+    );
+
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/example/src/handlers/v0/resources/get.test.ts
+++ b/domains/example/src/handlers/v0/resources/get.test.ts
@@ -5,24 +5,20 @@ import { handler } from "./get";
 
 describe("GET /v0/resources", () => {
   const endpoint = "/resources";
+
   const secrets = { udpNotificationSecret: "secret-value" }; // pragma: allowlist secret
 
-  describe("response", () => {
-    it("returns 200 with resolved resources", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withSecret(secrets).create(),
-      );
+  it("returns 200 with resolved resources", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        ssm: { param: expect.any(Number) as number },
-        secret: { secret: expect.any(Number) as number },
-        kms: { key: expect.any(Number) as number },
-      });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      ssm: { param: expect.any(Number) as number },
+      secret: { secret: expect.any(Number) as number },
+      kms: { key: expect.any(Number) as number },
     });
   });
 });

--- a/domains/example/src/handlers/v0/resources/runtime/get.test.ts
+++ b/domains/example/src/handlers/v0/resources/runtime/get.test.ts
@@ -5,22 +5,18 @@ import { handler } from "./get";
 
 describe("GET /v0/resources/runtime", () => {
   const endpoint = "/resources/runtime";
-  const params = { privateGatewaysRoot: "param-value" };
 
-  describe("response", () => {
-    it("returns 200 with resolved resources", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withParams(params).create(),
-      );
+  const params = { privateGatewaysRoot: "test-param-value" };
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        ssm: { param: expect.any(Number) as number },
-      });
+  it("returns 200 with resolved resources", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint),
+      sdk.context({ params }),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      ssm: { param: expect.any(Number) as number },
     });
   });
 });

--- a/domains/example/src/handlers/v0/todos/[id]/delete.test.ts
+++ b/domains/example/src/handlers/v0/todos/[id]/delete.test.ts
@@ -9,46 +9,30 @@ vi.mock("@data/store");
 
 describe("DELETE /v0/todos/:id", () => {
   const endpoint = "/todos";
+
   const todoId = createTodoId("todo-uuid");
-  const event = {
-    httpMethod: "DELETE",
-    path: endpoint,
-    pathParameters: { id: todoId },
-  };
 
-  describe("response", () => {
-    it("returns 204 when todo is deleted", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.delete).mockResolvedValue(true);
+  it("returns 204 when the todo is deleted", async ({ sdk }) => {
+    vi.mocked(store.delete).mockResolvedValue(true);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.delete(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.delete)).toHaveBeenCalledExactlyOnceWith(todoId);
-
-      expect(result.statusCode).toBe(204);
-    });
+    expect(vi.mocked(store.delete)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(204);
   });
 
-  describe("errors", () => {
-    it("returns 404 when todo deletion fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.delete).mockResolvedValue(false);
+  it("returns 404 when the todo deletion fails", async ({ sdk }) => {
+    vi.mocked(store.delete).mockResolvedValue(false);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.delete(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.delete)).toHaveBeenCalledExactlyOnceWith(todoId);
-
-      expect(result.statusCode).toBe(404);
-    });
+    expect(vi.mocked(store.delete)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(404);
   });
 });

--- a/domains/example/src/handlers/v0/todos/[id]/duplicate/post.test.ts
+++ b/domains/example/src/handlers/v0/todos/[id]/duplicate/post.test.ts
@@ -2,7 +2,6 @@ import { store } from "@data/store";
 import { it } from "@flex/testing";
 import type { Todo } from "@schemas/todos";
 import { createTodoId } from "@utils/parser";
-import nock from "nock";
 import { describe, expect, vi } from "vitest";
 
 import { handler } from "./post";
@@ -10,15 +9,10 @@ import { handler } from "./post";
 vi.mock("@data/store");
 
 describe("POST /v0/todos/:id/duplicate", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
   const endpoint = "/todos";
 
   const todoId = createTodoId("todo-uuid");
-  const event = {
-    httpMethod: "POST",
-    path: endpoint,
-    pathParameters: { id: todoId },
-  };
+
   const todo: Todo = {
     id: todoId,
     title: "Todo #1",
@@ -34,71 +28,49 @@ describe("POST /v0/todos/:id/duplicate", () => {
     createdAt: "2026-04-01T12:00:00.000Z",
   };
 
-  describe("response", () => {
-    it("returns 201 with the duplicated todo", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.getById).mockResolvedValue(todo);
+  it("returns 201 with the duplicated todo", async ({ http, sdk }) => {
+    vi.mocked(store.getById).mockResolvedValue(todo);
 
-      api
-        .post("/domains/example/v0/todos", {
-          title: "Todo #1 (copy)",
-          completed: false,
-          priority: "low",
-        })
-        .reply(200, duplicatedTodo);
+    http
+      .domain("example", "v0")
+      .post("/todos", {
+        body: { title: "Todo #1 (copy)", completed: false, priority: "low" },
+      })
+      .reply(200, duplicatedTodo);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.post(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
-
-      expect(result.statusCode).toBe(201);
-      expect(JSON.parse(result.body)).toStrictEqual(duplicatedTodo);
-    });
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(201);
+    expect(JSON.parse(result.body)).toStrictEqual(duplicatedTodo);
   });
 
-  describe("errors", () => {
-    it("returns 404 when todo does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.getById).mockResolvedValue(null);
+  it("returns 404 when the todo does not exist", async ({ sdk }) => {
+    vi.mocked(store.getById).mockResolvedValue(null);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          pathParameters: { id: "unknown" },
-        }),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.post(endpoint, { params: { id: "unknown" } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(
-        "unknown",
-      );
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith("unknown");
+    expect(result.statusCode).toBe(404);
+  });
 
-      expect(result.statusCode).toBe(404);
-    });
+  it("returns 502 when the integration fails", async ({ http, sdk }) => {
+    vi.mocked(store.getById).mockResolvedValue(todo);
 
-    it("returns 502 when integration fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.getById).mockResolvedValue(todo);
+    http.domain("example", "v0").post("/todos").reply(500);
 
-      api.post("/domains/example/v0/todos").reply(500);
+    const result = await handler(
+      sdk.event.post(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
-
-      expect(result.statusCode).toBe(502);
-    });
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/example/src/handlers/v0/todos/[id]/get.test.ts
+++ b/domains/example/src/handlers/v0/todos/[id]/get.test.ts
@@ -2,7 +2,7 @@ import { store } from "@data/store";
 import { it } from "@flex/testing";
 import type { Todo } from "@schemas/todos";
 import { createTodoId } from "@utils/parser";
-import { afterEach, beforeEach, describe, expect, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
 import { handler } from "./get";
 
@@ -10,13 +10,10 @@ vi.mock("@data/store");
 
 describe("GET /v0/todos/:id", () => {
   const endpoint = "/todos";
-  const todoId = createTodoId("todo-uuid");
-  const event = {
-    httpMethod: "GET",
-    path: endpoint,
-    pathParameters: { id: todoId },
-  };
-  const existingTodo: Todo = {
+
+  const todoId = createTodoId("test-todo-id");
+
+  const todo: Todo = {
     id: todoId,
     title: "Todo #1",
     completed: true,
@@ -24,85 +21,54 @@ describe("GET /v0/todos/:id", () => {
     createdAt: "2026-03-29T11:00:00.000Z",
   };
 
-  beforeEach(() => {
-    vi.stubEnv("enableTodoMetadata", "false");
+  it.beforeEach(({ env }) => {
+    env.set({ enableTodoMetadata: "false" });
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
+  it("returns 200 with the existing todo", async ({ sdk }) => {
+    vi.mocked(store.getById).mockResolvedValue(todo);
+
+    const result = await handler(
+      sdk.event.get(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
+
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(todo);
   });
 
-  describe("response", () => {
-    it("returns 200 with existing todo", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.getById).mockResolvedValue(existingTodo);
+  it("returns 404 when the todo does not exist", async ({ sdk }) => {
+    vi.mocked(store.getById).mockResolvedValue(null);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { params: { id: "unknown" } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual(existingTodo);
-    });
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith("unknown");
+    expect(result.statusCode).toBe(404);
   });
 
-  describe("errors", () => {
-    it("returns 404 when todo does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.getById).mockResolvedValue(null);
+  it("includes todo metadata when enableTodoMetadata is enabled", async ({
+    env,
+    sdk,
+  }) => {
+    env.set({ enableTodoMetadata: "true" });
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          pathParameters: { id: "unknown" },
-        }),
-        context.create(),
-      );
+    const todoWithMetadata = {
+      ...todo,
+      meta: { label: todo.priority.toUpperCase() },
+    };
+    vi.mocked(store.getById).mockResolvedValue(todoWithMetadata);
 
-      expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(
-        "unknown",
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { params: { id: todoId } }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(404);
-    });
-  });
-
-  describe("feature flags", () => {
-    describe("enableTodoMetadata", () => {
-      const todoWithMetadata = {
-        ...existingTodo,
-        meta: { label: existingTodo.priority.toUpperCase() },
-      };
-
-      beforeEach(() => {
-        vi.stubEnv("enableTodoMetadata", "true");
-      });
-
-      it("includes todo metadata when enabled", async ({
-        context,
-        privateGatewayEventWithAuthorizer,
-      }) => {
-        vi.mocked(store.getById).mockResolvedValue(todoWithMetadata);
-
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.create(event),
-          context.create(),
-        );
-
-        expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(
-          todoId,
-        );
-
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toStrictEqual(todoWithMetadata);
-      });
-    });
+    expect(vi.mocked(store.getById)).toHaveBeenCalledExactlyOnceWith(todoId);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(todoWithMetadata);
   });
 });

--- a/domains/example/src/handlers/v0/todos/get.test.ts
+++ b/domains/example/src/handlers/v0/todos/get.test.ts
@@ -1,7 +1,6 @@
 import { store, TODOS } from "@data/store";
 import { it } from "@flex/testing";
-import type { APIGatewayProxyEventQueryStringParameters } from "aws-lambda";
-import { afterEach, beforeEach, describe, expect, vi } from "vitest";
+import { describe, expect, vi } from "vitest";
 
 import { handler } from "./get";
 
@@ -9,188 +8,131 @@ vi.mock("@data/store");
 
 describe("GET /v0/todos", () => {
   const endpoint = "/todos";
-  const event = { httpMethod: "GET", path: endpoint };
 
-  beforeEach(() => {
-    vi.stubEnv("enableTodoMetadata", "false");
+  it.beforeEach(({ env }) => {
+    env.set({ enableTodoMetadata: "false" });
   });
 
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  describe("request validation", () => {
-    it.for<{
-      queryStringParameters: APIGatewayProxyEventQueryStringParameters;
-      reason: string;
-      expected: { field: string };
-    }>([
-      {
-        queryStringParameters: { priority: "unknown" },
-        reason: "contains invalid priority",
-        expected: { field: "priority" },
-      },
-      {
-        queryStringParameters: { limit: "0" },
-        reason: "contains limit below minimum",
-        expected: { field: "limit" },
-      },
-      {
-        queryStringParameters: { limit: "101" },
-        reason: "contains limit above maximum",
-        expected: { field: "limit" },
-      },
-    ])(
-      "returns 400 when query $reason",
-      async (
-        { queryStringParameters, expected },
-        { context, privateGatewayEventWithAuthorizer },
-      ) => {
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.create({
-            ...event,
-            queryStringParameters,
-          }),
-          context.create(),
-        );
-
-        expect(result.statusCode).toBe(400);
-        expect(JSON.parse(result.body)).toStrictEqual({
-          message: "Invalid query parameters",
-          errors: [
-            { field: expected.field, message: expect.any(String) as string },
-          ],
-        });
-      },
+  it.for<{
+    query: Record<string, string>;
+    reason: string;
+    field: string;
+  }>([
+    {
+      query: { priority: "unknown" },
+      reason: "contains invalid priority",
+      field: "priority",
+    },
+    {
+      query: { limit: "0" },
+      reason: "contains limit below minimum",
+      field: "limit",
+    },
+    {
+      query: { limit: "101" },
+      reason: "contains limit above maximum",
+      field: "limit",
+    },
+  ])("returns 400 when query $reason", async ({ query, field }, { sdk }) => {
+    const result = await handler(
+      sdk.event.get(endpoint, { query }),
+      sdk.context(),
     );
-  });
 
-  describe("response", () => {
-    it("returns 200 with all todos", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.list).mockResolvedValue(TODOS);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ todos: TODOS, total: 3 });
-    });
-
-    it("returns 200 with todos filtered by completed status", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.list).mockResolvedValue(TODOS);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          queryStringParameters: { completed: "true" },
-        }),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        todos: [TODOS[0]],
-        total: 1,
-      });
-    });
-
-    it("returns 200 with todos filtered by priority", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.list).mockResolvedValue(TODOS);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          queryStringParameters: { priority: "low" },
-        }),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        todos: [TODOS[0]],
-        total: 1,
-      });
-    });
-
-    it("returns 200 with paginated results", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.list).mockResolvedValue(TODOS);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          queryStringParameters: { limit: "1", page: "2" },
-        }),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({
-        todos: [TODOS[1]],
-        total: 3,
-      });
-    });
-
-    it("returns 200 with no results", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(store.list).mockResolvedValue(TODOS);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create({
-          ...event,
-          queryStringParameters: { completed: "true", priority: "high" },
-        }),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ todos: [], total: 0 });
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      message: "Invalid query parameters",
+      errors: [{ field, message: expect.any(String) as string }],
     });
   });
 
-  describe("feature flags", () => {
-    describe("enableTodoMetadata", () => {
-      const todosWithMetadata = TODOS.map((t) => ({
-        ...t,
-        meta: { label: t.priority.toUpperCase() },
-      }));
+  it("returns 200 with all todos", async ({ sdk }) => {
+    vi.mocked(store.list).mockResolvedValue(TODOS);
 
-      beforeEach(() => {
-        vi.stubEnv("enableTodoMetadata", "true");
-      });
+    const result = await handler(sdk.event.get(endpoint), sdk.context());
 
-      it("includes todo metadata when enabled", async ({
-        context,
-        privateGatewayEventWithAuthorizer,
-      }) => {
-        vi.mocked(store.list).mockResolvedValue(TODOS);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ todos: TODOS, total: 3 });
+  });
 
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.create(event),
-          context.create(),
-        );
+  it("returns 200 with todos filtered by completed status", async ({ sdk }) => {
+    vi.mocked(store.list).mockResolvedValue(TODOS);
 
-        expect(result.statusCode).toBe(200);
-        expect(JSON.parse(result.body)).toStrictEqual({
-          todos: todosWithMetadata,
-          total: 3,
-        });
-      });
+    const result = await handler(
+      sdk.event.get(endpoint, { query: { completed: "true" } }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      todos: [TODOS[0]],
+      total: 1,
+    });
+  });
+
+  it("returns 200 with todos filtered by priority", async ({ sdk }) => {
+    vi.mocked(store.list).mockResolvedValue(TODOS);
+
+    const result = await handler(
+      sdk.event.get(endpoint, { query: { priority: "low" } }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      todos: [TODOS[0]],
+      total: 1,
+    });
+  });
+
+  it("returns 200 with paginated results", async ({ sdk }) => {
+    vi.mocked(store.list).mockResolvedValue(TODOS);
+
+    const result = await handler(
+      sdk.event.get(endpoint, { query: { limit: "1", page: "2" } }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      todos: [TODOS[1]],
+      total: 3,
+    });
+  });
+
+  it("returns 200 with no results", async ({ sdk }) => {
+    vi.mocked(store.list).mockResolvedValue(TODOS);
+
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        query: { completed: "true", priority: "high" },
+      }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ todos: [], total: 0 });
+  });
+
+  it("includes todo metadata when enableTodoMetadata is enabled", async ({
+    env,
+    sdk,
+  }) => {
+    env.set({ enableTodoMetadata: "true" });
+
+    const todosWithMetadata = TODOS.map((t) => ({
+      ...t,
+      meta: { label: t.priority.toUpperCase() },
+    }));
+
+    vi.mocked(store.list).mockResolvedValue(TODOS);
+
+    const result = await handler(sdk.event.get(endpoint), sdk.context());
+
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      todos: todosWithMetadata,
+      total: 3,
     });
   });
 });

--- a/domains/example/src/handlers/v0/todos/post.private.test.ts
+++ b/domains/example/src/handlers/v0/todos/post.private.test.ts
@@ -1,28 +1,22 @@
 import { store } from "@data/store";
 import { it } from "@flex/testing";
-import { Todo } from "@schemas/todos";
+import type { Todo } from "@schemas/todos";
 import { createTodoId } from "@utils/parser";
-import {
-  afterAll,
-  afterEach,
-  beforeAll,
-  beforeEach,
-  describe,
-  expect,
-  vi,
-} from "vitest";
+import { afterAll, beforeAll, describe, expect, vi } from "vitest";
 
 import { handler } from "./post.private";
 
 vi.mock("node:crypto", () => ({
-  default: { randomUUID: vi.fn().mockReturnValue("test-uuid") },
+  default: { randomUUID: vi.fn().mockReturnValue("test-todo-id") },
 }));
 vi.mock("@data/store");
 
 describe("POST /v0/todos [private]", () => {
   const endpoint = "/todos";
-  const todoId = createTodoId("test-uuid");
-  const createdTodo: Todo = {
+
+  const todoId = createTodoId("test-todo-id");
+
+  const todo: Todo = {
     id: todoId,
     title: "My todo",
     completed: false,
@@ -39,85 +33,58 @@ describe("POST /v0/todos [private]", () => {
     vi.useRealTimers();
   });
 
-  beforeEach(() => {
-    vi.stubEnv("enableTodoMetadata", "false");
-  });
-
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
-  describe("request validation", () => {
-    it.for([
-      { body: {}, reason: "is empty" },
-      { body: { title: "" }, reason: "contains empty title" },
-      {
-        body: { title: "Title", priority: "unknown" },
-        reason: "contains invalid priority",
-      },
-    ])(
-      "returns 400 when payload $reason",
-      async ({ body }, { context, privateGatewayEventWithAuthorizer }) => {
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.post(endpoint, { body }),
-          context.create(),
-        );
-
-        expect(result.statusCode).toBe(400);
-        expect(JSON.parse(result.body)).toStrictEqual({
-          message: "Invalid request body",
-        });
-      },
+  it.for([
+    { body: {}, reason: "is empty" },
+    { body: { title: "" }, reason: "contains empty title" },
+    {
+      body: { title: "Title", priority: "unknown" },
+      reason: "contains invalid priority",
+    },
+  ])("returns 400 when payload $reason", async ({ body }, { sdk }) => {
+    const result = await handler(
+      sdk.event.post(endpoint, { body }),
+      sdk.context(),
     );
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      message: "Invalid request body",
+    });
   });
 
-  describe("response", () => {
-    it("returns 200 with created todo", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.post(endpoint, {
-          body: { title: "My todo" },
-        }),
-        context.create(),
-      );
+  it("returns 200 with created todo", async ({ sdk }) => {
+    const result = await handler(
+      sdk.event.post(endpoint, { body: { title: "My todo" } }),
+      sdk.context(),
+    );
 
-      expect(vi.mocked(store.create)).toHaveBeenCalledExactlyOnceWith(
-        createdTodo,
-      );
+    expect(vi.mocked(store.create)).toHaveBeenCalledExactlyOnceWith(todo);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(todo);
+  });
 
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual(createdTodo);
-    });
+  it("returns 200 with created todo when full payload is provided", async ({
+    sdk,
+  }) => {
+    const payload: Pick<Todo, "title" | "completed" | "priority"> = {
+      title: "My todo",
+      completed: true,
+      priority: "high",
+    };
 
-    it("returns 200 with created todo when full payload is provided", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const payload: Pick<Todo, "title" | "completed" | "priority"> = {
-        title: "My todo",
-        completed: true,
-        priority: "high",
-      };
+    const expected: Todo = {
+      ...payload,
+      id: todoId,
+      createdAt: "2026-04-01T12:00:00.000Z",
+    };
 
-      const expectedTodo: Todo = {
-        ...payload,
-        id: createTodoId("test-uuid"),
-        createdAt: "2026-04-01T12:00:00.000Z",
-      };
+    const result = await handler(
+      sdk.event.post(endpoint, { body: payload }),
+      sdk.context(),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.post(endpoint, { body: payload }),
-        context.create(),
-      );
-
-      expect(vi.mocked(store.create)).toHaveBeenCalledExactlyOnceWith(
-        expectedTodo,
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual(expectedTodo);
-    });
+    expect(vi.mocked(store.create)).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(expected);
   });
 });

--- a/domains/example/src/handlers/v0/users/notifications/get.test.ts
+++ b/domains/example/src/handlers/v0/users/notifications/get.test.ts
@@ -1,15 +1,17 @@
 import { createUserId, it } from "@flex/testing";
-import nock from "nock";
 import { describe, expect } from "vitest";
 
 import { handler } from "./get";
 
 describe("GET /v0/users/notifications", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
-  const userId = createUserId("test-pairwise-id");
-  const testPushId = "push-12345";
+  const endpoint = "/users/notifications";
 
-  const mockNotificationsData = [
+  const userId = createUserId("test-pairwise-id");
+  // TODO: Create a branded cast for push IDs?
+  const pushId = "test-push-id";
+  const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
+
+  const notifications = [
     {
       NotificationID: "123456",
       Status: "READ",
@@ -21,66 +23,55 @@ describe("GET /v0/users/notifications", () => {
     },
   ];
 
-  const mockUdpPushIdSuccess = () =>
-    api
-      .get("/domains/udp/v1/users/push-id")
-      .matchHeader("User-Id", userId)
-      .reply(200, { pushId: testPushId });
-
-  const mockUnsNotificationsSuccess = () =>
-    api
-      .get("/gateways/uns/v1/notifications")
-      .query({ externalUserID: testPushId })
-      .reply(200, mockNotificationsData);
-
-  it("returns 200 and notifications data on success", async ({
-    context,
-    privateGatewayEventWithAuthorizer,
-  }) => {
-    mockUdpPushIdSuccess();
-    mockUnsNotificationsSuccess();
+  it("returns 200 with notifications", async ({ http, sdk }) => {
+    http
+      .domain("udp")
+      .get("/users/push-id", { headers: { "User-Id": userId } })
+      .reply(200, { pushId });
+    http
+      .gateway("uns")
+      .get("/notifications", { query: { externalUserID: pushId } })
+      .reply(200, notifications);
 
     const result = await handler(
-      privateGatewayEventWithAuthorizer.authenticated({}, userId),
-      context.withSecret({ udpNotificationSecret: "test-value" }).create(), // pragma: allowlist secret
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
     );
 
     expect(result.statusCode).toBe(200);
-    expect(JSON.parse(result.body)).toStrictEqual(mockNotificationsData);
+    expect(JSON.parse(result.body)).toStrictEqual(notifications);
   });
 
-  describe("Error scenarios", () => {
-    it("returns 502 if UDP push ID lookup fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api.get("/domains/udp/v1/users/push-id").reply(500);
+  it("returns 502 when the push ID lookup fails", async ({ http, sdk }) => {
+    http.domain("udp").get("/users/push-id").reply(500);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.authenticated({}, userId),
-        context.withSecret({ udpNotificationSecret: "test-value" }).create(), // pragma: allowlist secret
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(502);
+  });
 
-    it("returns 502 if UNS notifications lookup fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      mockUdpPushIdSuccess();
+  it("returns 502 when the notifications lookup fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .domain("udp")
+      .get("/users/push-id", { headers: { "User-Id": userId } })
+      .reply(200, { pushId });
 
-      api
-        .get("/gateways/uns/v1/notifications")
-        .query({ externalUserID: testPushId })
-        .reply(404);
+    http
+      .gateway("uns")
+      .get("/notifications", { query: { externalUserID: pushId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.authenticated({}, userId),
-        context.withSecret({ udpNotificationSecret: "test-value" }).create(), // pragma: allowlist secret
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/example/src/handlers/v0/users/notifications/patch.test.ts
+++ b/domains/example/src/handlers/v0/users/notifications/patch.test.ts
@@ -1,91 +1,77 @@
 import { createUserId, it } from "@flex/testing";
-import nock from "nock";
 import { describe, expect } from "vitest";
 
 import { handler } from "./patch";
 
 describe("PATCH /v0/users/notifications", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
   const endpoint = "/users/notifications";
 
   const userId = createUserId("test-pairwise-id");
+  // TODO: Create a branded cast for push IDs?
+  const pushId = "test-push-id";
+  const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
 
-  const mockUdpGetPushIdSuccess = () =>
-    api
-      .get("/domains/udp/v1/users/push-id")
-      .matchHeader("User-Id", userId)
-      .reply(200, {
-        pushId: "derived-notification-id",
-      });
+  const notifications = { consentStatus: "accepted", pushId };
 
-  it("updates user notifications successfully and returns 204 with updated notifications", async ({
-    context,
-    privateGatewayEventWithAuthorizer,
+  it("returns 200 with updated notifications and feature flags", async ({
+    http,
+    sdk,
   }) => {
-    mockUdpGetPushIdSuccess();
-    api
-      .post("/gateways/udp/v1/notifications")
-      .matchHeader("requesting-service-user-id", userId)
-      .reply(200, {
-        consentStatus: "accepted",
-        pushId: "derived-notification-id",
-      });
+    http
+      .domain("udp")
+      .get("/users/push-id", { headers: { "User-Id": userId } })
+      .reply(200, { pushId });
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: { "requesting-service-user-id": userId },
+        body: { consentStatus: "accepted", pushId },
+      })
+      .reply(200, notifications);
 
     const result = await handler(
-      privateGatewayEventWithAuthorizer.patch(endpoint, {
+      sdk.event.patch(endpoint, {
+        userId,
         body: { consentStatus: "accepted" },
       }),
-      context
-        .withSecret({ udpNotificationSecret: "test-notification-value" }) // pragma: allowlist secret
-        .create(),
+      sdk.context({ secrets }),
     );
 
     expect(result.statusCode).toBe(200);
-    expect(result.body).toBe(
-      JSON.stringify({
-        consentStatus: "accepted",
-        pushId: "derived-notification-id",
-        featureFlags: {
-          newUserProfileEnabled: true,
-        },
-      }),
-    );
+    expect(JSON.parse(result.body)).toStrictEqual({
+      ...notifications,
+      featureFlags: { newUserProfileEnabled: true },
+    });
   });
 
   it.for([
-    {
-      body: { consentStatus: "invalid" },
-      reason: "passes an invalid consent status",
-    },
-    { body: {}, reason: "is empty" },
-  ])(
-    "returns 400 when body $reason",
-    async ({ body }, { context, privateGatewayEventWithAuthorizer }) => {
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.patch(endpoint, { body }),
-        context
-          .withSecret({ udpNotificationSecret: "test-notification-value" }) // pragma: allowlist secret
-          .create(),
-      );
+    { body: { consentStatus: "invalid" }, reason: "an invalid consent status" },
+    { body: {}, reason: "empty" },
+  ])("returns 400 when body is $reason", async ({ body }, { sdk }) => {
+    const result = await handler(
+      sdk.event.patch(endpoint, { userId, body }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(400);
-    },
-  );
+    expect(result.statusCode).toBe(400);
+  });
 
-  it("returns 502 when updating user notifications fails", async ({
-    context,
-    privateGatewayEventWithAuthorizer,
+  it("returns 502 when the notifications update fails", async ({
+    http,
+    sdk,
   }) => {
-    mockUdpGetPushIdSuccess();
-    api.post("/gateways/udp/v1/notifications").reply(500);
+    http
+      .domain("udp")
+      .get("/users/push-id", { headers: { "User-Id": userId } })
+      .reply(200, { pushId });
+    http.gateway("udp").post("/notifications").reply(500);
 
     const result = await handler(
-      privateGatewayEventWithAuthorizer.patch(endpoint, {
+      sdk.event.patch(endpoint, {
+        userId,
         body: { consentStatus: "accepted" },
       }),
-      context
-        .withSecret({ udpNotificationSecret: "test-notification-value" }) // pragma: allowlist secret
-        .create(),
+      sdk.context({ secrets }),
     );
 
     expect(result.statusCode).toBe(502);

--- a/libs/testing/src/fixtures/sdk.test.ts
+++ b/libs/testing/src/fixtures/sdk.test.ts
@@ -10,6 +10,7 @@ import { createUserId } from "./user";
 
 describe("createSdkEvent", () => {
   const sdkEvent = createSdkEvent();
+  const userId = createUserId("custom-user");
 
   it("returns the base event when called with no arguments", () => {
     expect(sdkEvent()).toStrictEqual(baseSdkEvent);
@@ -17,12 +18,12 @@ describe("createSdkEvent", () => {
 
   it("merges base event with overrides when provided", () => {
     const event = sdkEvent({
-      path: "/new",
+      path: "/test",
       headers: { "x-custom": "value" },
       requestContext: { authorizer: { pairwiseId: "custom-user" } },
     });
 
-    expect(event.path).toBe("/new");
+    expect(event.path).toBe("/test");
     expect(event.headers).toStrictEqual({
       "Content-Type": "application/json",
       "x-custom": "value",
@@ -37,28 +38,50 @@ describe("createSdkEvent", () => {
   it.each(["get", "delete"] as const)(
     'variant "%s" sets httpMethod and path',
     (method) => {
-      const event = sdkEvent[method]("/method");
+      const event = sdkEvent[method]("/test");
 
       expect(event.httpMethod).toBe(method.toUpperCase());
-      expect(event.path).toBe("/method");
+      expect(event.path).toBe("/test");
     },
   );
 
   it.each(["post", "put", "patch"] as const)(
     'variant "%s" sets httpMethod, path and body',
     (method) => {
-      const event = sdkEvent[method]("/method", { body: { key: "value" } });
+      const event = sdkEvent[method]("/test", { body: { key: "value" } });
 
       expect(event.httpMethod).toBe(method.toUpperCase());
-      expect(event.path).toBe("/method");
+      expect(event.path).toBe("/test");
       expect(event.body).toBe(JSON.stringify({ key: "value" }));
     },
   );
 
-  it("serialises query parameters", () => {
+  it("serialises query parameters when query is provided", () => {
     expect(
-      sdkEvent.get("/", { query: { page: 1 } }).queryStringParameters,
+      sdkEvent.get("/test", { query: { page: 1 } }).queryStringParameters,
     ).toEqual({ page: "1" });
+  });
+
+  it("sets event path parameters when params are provided", () => {
+    expect(
+      sdkEvent.get("/test", { params: { id: "test-id" } }).pathParameters,
+    ).toStrictEqual({ id: "test-id" });
+  });
+
+  it("creates authenticated event when user ID is provided", () => {
+    const event = sdkEvent.get("/test", { userId });
+
+    expect(event.requestContext.authorizer).toStrictEqual({
+      principalId: userId,
+      integrationLatency: 0,
+      pairwiseId: userId,
+    });
+  });
+
+  it("keeps the default authorizer when user ID is not provided", () => {
+    expect(sdkEvent.get("/test").requestContext.authorizer).toStrictEqual(
+      baseSdkEvent.requestContext.authorizer,
+    );
   });
 });
 

--- a/libs/testing/src/fixtures/sdk.ts
+++ b/libs/testing/src/fixtures/sdk.ts
@@ -18,7 +18,9 @@ export type SdkEvent = APIGatewayProxyWithLambdaAuthorizerEvent<{
 
 interface SdkEventRequestOptions {
   headers?: Record<string, string>;
+  params?: Record<string, string>;
   query?: QueryParams;
+  userId?: UserId;
 }
 
 export const baseSdkEvent: SdkEvent = {
@@ -87,13 +89,19 @@ type SdkEventOverrides = SdkEventRequestOptions & { body?: unknown };
 function toRequest(
   httpMethod: string,
   path: string,
-  { body, headers, query }: SdkEventOverrides = {},
+  { body, headers, params, query, userId }: SdkEventOverrides = {},
 ): DeepPartial<SdkEvent> {
   return {
     httpMethod,
     path,
     headers: { "Content-Type": "application/json", ...headers },
     queryStringParameters: extractQueryParams(query)[1],
+    ...(params && { pathParameters: params }),
+    ...(userId && {
+      requestContext: {
+        authorizer: { principalId: userId, pairwiseId: userId },
+      },
+    }),
     ...(body !== undefined && { body: JSON.stringify(body) }),
   };
 }
@@ -105,11 +113,11 @@ export function createSdkEvent() {
   return createFixtureFactory(baseSdkEvent, (build) => ({
     get: (path: string, options?: SdkEventOptions) =>
       build(toRequest("GET", path, options)),
-    post: <Body>(path: string, options: SdkEventOptions<Body>) =>
+    post: <Body = never>(path: string, options?: SdkEventOptions<Body>) =>
       build(toRequest("POST", path, options)),
-    put: <Body>(path: string, options: SdkEventOptions<Body>) =>
+    put: <Body = never>(path: string, options?: SdkEventOptions<Body>) =>
       build(toRequest("PUT", path, options)),
-    patch: <Body>(path: string, options: SdkEventOptions<Body>) =>
+    patch: <Body = never>(path: string, options?: SdkEventOptions<Body>) =>
       build(toRequest("PATCH", path, options)),
     delete: (path: string, options?: SdkEventOptions) =>
       build(toRequest("DELETE", path, options)),


### PR DESCRIPTION
# Pull Request

## Description

- Update all test suites to use `http` and `sdk` fixtures
- Add support for `userId` in sdk events
- Add support for `params` in sdk events

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-240

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (code change that does not add functionality or fix a bug)
- [x] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined