### PR TITLE
test(udp): use http and sdk fixtures

### DIFF
--- a/domains/udp/src/handlers/v1/identity/[service]/[id]/post.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/[id]/post.test.ts
@@ -1,146 +1,146 @@
-import { createUserId, it } from "@flex/testing";
-import type {
-  CreateServiceIdentityLinkRequest,
-  GetServiceIdentityLinkResponse,
-} from "@schemas/identity";
-import status from "http-status";
-import nock from "nock";
+import { it } from "@flex/testing";
+import { userId } from "@tests/fixtures";
 import { describe, expect } from "vitest";
 
 import { handler } from "./post";
 
 describe("POST /v1/identity/:service/:id", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
-
-  const service = "test-service";
+  const serviceName = "test-service";
   const serviceId = "test-service-id";
-  const endpoint = `/identity/${service}/${serviceId}`;
-  const userId = createUserId("test-pairwise-id");
-  const body: CreateServiceIdentityLinkRequest = { appId: userId };
+  const existingServiceId = "test-existing-service-id";
+  const endpoint = `/identity/${serviceName}/${serviceId}`;
 
-  const event = {
-    httpMethod: "POST",
-    path: endpoint,
-    pathParameters: { service, id: serviceId },
-  };
+  const identity = { appId: userId };
+  const linked = { serviceId, serviceName };
 
-  describe("response", () => {
-    it("returns 201 when a new service identity is linked (none existed)", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      // 1. Initial check returns 404 (not linked)
-      api.get(`/gateways/udp/v1/identity/${service}`).reply(status.NOT_FOUND);
+  it("returns 201 when an identity link succeeds", async ({ http, sdk }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(404);
+    http
+      .gateway("udp")
+      .post(`/identity/${serviceName}/${serviceId}`, { body: identity })
+      .reply(201);
 
-      // 2. Then create the new link
-      api
-        .post(`/gateways/udp/v1/identity/${service}/${serviceId}`, body)
-        .reply(status.CREATED);
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result).toStrictEqual({ statusCode: status.CREATED, body: "" });
-    });
-
-    it("returns 204 when the identity is already linked with the same ID", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const existingLink: GetServiceIdentityLinkResponse = {
-        serviceId: serviceId,
-        serviceName: service,
-      };
-
-      // 1. Initial check finds existing link
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .reply(status.OK, existingLink);
-
-      /** No POST or DELETE should occur */
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result).toStrictEqual({ statusCode: status.NO_CONTENT, body: "" });
-    });
-
-    it("returns 201 after unlinking an old ID if a different ID exists", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      const oldId = "old-id";
-      const existingLink: GetServiceIdentityLinkResponse = {
-        serviceId: oldId,
-        serviceName: service,
-      };
-
-      // 1. Initial check finds an OLD ID
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .reply(status.OK, existingLink);
-
-      // 2. Logic should trigger a DELETE for the old link
-      api
-        .delete(`/gateways/udp/v1/identity/${service}/${oldId}`)
-        .reply(status.NO_CONTENT);
-
-      // 3. Then create the NEW link
-      api
-        .post(`/gateways/udp/v1/identity/${service}/${serviceId}`, body)
-        .reply(status.CREATED);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result).toStrictEqual({ statusCode: status.CREATED, body: "" });
-    });
+    expect(result.statusCode).toBe(201);
+    expect(result.body).toBe("");
   });
 
-  describe("errors", () => {
-    it("returns 502 when the initial check fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      // Logic fails at the first step
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .reply(status.INTERNAL_SERVER_ERROR);
+  it("returns 204 when an identity link already exists", async ({
+    http,
+    sdk,
+  }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(200, linked);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
 
-      expect(result).toStrictEqual({
-        statusCode: status.BAD_GATEWAY,
-        body: "",
-      });
+    expect(result.statusCode).toBe(204);
+    expect(result.body).toBe("");
+  });
+
+  it("returns 201 when an existing identity link ID is replaced", async ({
+    http,
+    sdk,
+  }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(200, {
+      serviceId: existingServiceId,
+      serviceName,
     });
+    http
+      .gateway("udp")
+      .delete(`/identity/${serviceName}/${existingServiceId}`)
+      .reply(204);
+    http
+      .gateway("udp")
+      .post(`/identity/${serviceName}/${serviceId}`, { body: identity })
+      .reply(201);
 
-    it("returns 502 when the creation (post) fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api.get(`/gateways/udp/v1/identity/${service}`).reply(status.NOT_FOUND);
-      api
-        .post(`/gateways/udp/v1/identity/${service}/${serviceId}`, body)
-        .reply(status.INTERNAL_SERVER_ERROR);
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    expect(result.statusCode).toBe(201);
+    expect(result.body).toBe("");
+  });
 
-      expect(result).toStrictEqual({
-        statusCode: status.BAD_GATEWAY,
-        body: "",
-      });
+  it("returns 502 when the UDP identity link integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(500);
+
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
+  });
+
+  it("returns 502 when the UDP delete identity link integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(200, {
+      serviceId: existingServiceId,
+      serviceName,
     });
+    http
+      .gateway("udp")
+      .delete(`/identity/${serviceName}/${existingServiceId}`)
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
+  });
+
+  it("returns 502 when the UDP identity link creation fails", async ({
+    http,
+    sdk,
+  }) => {
+    http.gateway("udp").get(`/identity/${serviceName}`).reply(404);
+    http
+      .gateway("udp")
+      .post(`/identity/${serviceName}/${serviceId}`, { body: identity })
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.post(endpoint, {
+        userId,
+        params: { service: serviceName, id: serviceId },
+      }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
   });
 });

--- a/domains/udp/src/handlers/v1/identity/[service]/[id]/post.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/[id]/post.ts
@@ -1,29 +1,29 @@
 import { route } from "@domain";
-import { UserId } from "@flex/utils";
-import status from "http-status";
-
+import type { UserId } from "@flex/utils";
 import {
   deleteServiceIdentity,
   getServiceIdentityLink,
   postServiceIdentity,
-} from "../../../../../services/identity";
+} from "@services/identity";
+import status from "http-status";
 
 export const handler = route(
   "POST /v1/identity/:service/:id",
   async ({ pathParams, auth }) => {
-    const { id: requestedId } = pathParams;
-    const existing = await getServiceIdentityLink(auth.pairwiseId as UserId);
+    const { id: serviceId } = pathParams;
 
-    if (existing) {
-      const isDifferentId = existing.serviceId !== requestedId;
+    // TODO: SDK auth alias
+    const userId = auth.pairwiseId as UserId;
 
-      /** If user is already linked return 204 */
-      if (!isDifferentId) {
+    const identity = await getServiceIdentityLink(userId);
+
+    if (identity) {
+      if (identity.serviceId === serviceId) {
         return { status: status.NO_CONTENT };
       }
 
       /** Remove old link if user is already linked and has a new linking ID */
-      await deleteServiceIdentity(existing.serviceName, existing.serviceId);
+      await deleteServiceIdentity(identity.serviceName, identity.serviceId);
     }
 
     await postServiceIdentity();

--- a/domains/udp/src/handlers/v1/identity/[service]/delete.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.test.ts
@@ -1,111 +1,90 @@
-import { createUserId, it } from "@flex/testing";
-import type { GetServiceIdentityLinkResponse } from "@schemas/identity";
-import nock from "nock";
+import { it } from "@flex/testing";
+import { userId } from "@tests/fixtures";
 import { describe, expect } from "vitest";
 
 import { handler } from "./delete";
 
 describe("DELETE /v1/identity/:service", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
-
-  const service = "test-service";
+  const serviceName = "test-service";
   const serviceId = "test-service-id";
-  const endpoint = `/identity/${service}/${serviceId}`;
+  const endpoint = `/identity/${serviceName}`;
 
-  const userId = createUserId("test-pairwise-id");
+  const identity = { serviceId, serviceName };
 
-  const foundServiceIdentityLink: GetServiceIdentityLinkResponse = {
-    serviceId: "existing-service-id",
-    serviceName: "existing-service-name",
-  };
+  it("returns 204 when an identity unlink succeeds", async ({ http, sdk }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
+    http
+      .gateway("udp")
+      .delete(`/identity/${identity.serviceName}/${identity.serviceId}`)
+      .reply(204);
 
-  const event = {
-    httpMethod: "DELETE",
-    path: endpoint,
-    pathParameters: { service, id: serviceId },
-  };
+    const result = await handler(
+      sdk.event.delete(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-  describe("response", () => {
-    it("returns 204 when an existing service identity is unlinked", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, foundServiceIdentityLink);
-
-      api
-        .delete(
-          `/gateways/udp/v1/identity/${foundServiceIdentityLink.serviceName}/${foundServiceIdentityLink.serviceId}`,
-        )
-        .reply(204);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result).toStrictEqual({ statusCode: 204, body: "" });
-    });
+    expect(result.statusCode).toBe(204);
+    expect(result.body).toBe("");
   });
 
-  describe("errors", () => {
-    it("returns 404 when service identity link does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(404);
+  it("returns 404 when an identity link does not exist", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.delete(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-      expect(result).toStrictEqual({ statusCode: 404, body: "" });
-    });
+    expect(result.statusCode).toBe(404);
+    expect(result.body).toBe("");
+  });
 
-    it("returns 502 when retrieving existing service identity link fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(500);
+  it("returns 502 when the UDP identity link integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(500);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.delete(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
+  });
 
-    it("returns 502 when unlinking service identity fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, foundServiceIdentityLink);
+  it("returns 502 when the UDP identity unlink integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
+    http
+      .gateway("udp")
+      .delete(`/identity/${identity.serviceName}/${identity.serviceId}`)
+      .reply(500);
 
-      api
-        .delete(
-          `/gateways/udp/v1/identity/${foundServiceIdentityLink.serviceName}/${foundServiceIdentityLink.serviceId}`,
-        )
-        .reply(500);
+    const result = await handler(
+      sdk.event.delete(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
   });
 });

--- a/domains/udp/src/handlers/v1/identity/[service]/delete.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.ts
@@ -1,21 +1,21 @@
 import { route } from "@domain";
-import { UserId } from "@flex/utils";
-import createHttpError from "http-errors";
-import status from "http-status";
-
+import type { UserId } from "@flex/utils";
 import {
   deleteServiceIdentity,
   getServiceIdentityLink,
-} from "../../../../services/identity";
+} from "@services/identity";
+import createHttpError from "http-errors";
+import status from "http-status";
 
 export const handler = route(
   "DELETE /v1/identity/:service",
   async ({ auth, pathParams, integrations }) => {
-    const linked = await getServiceIdentityLink(auth.pairwiseId as UserId);
+    // TODO: SDK auth alias
+    const userId = auth.pairwiseId as UserId;
 
-    if (!linked) {
-      throw new createHttpError.NotFound();
-    }
+    const identity = await getServiceIdentityLink(userId);
+
+    if (!identity) throw new createHttpError.NotFound();
 
     /**
      * NOTE:
@@ -24,11 +24,11 @@ export const handler = route(
     if (pathParams.service === "dvla") {
       await integrations.dvlaUnlinkUser({
         body: {},
-        path: `/${linked.serviceId}`,
+        path: `/${identity.serviceId}`,
       });
     }
 
-    await deleteServiceIdentity(linked.serviceName, linked.serviceId);
+    await deleteServiceIdentity(identity.serviceName, identity.serviceId);
 
     return { status: status.NO_CONTENT };
   },

--- a/domains/udp/src/handlers/v1/identity/[service]/get.private.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/get.private.test.ts
@@ -1,78 +1,77 @@
-import { createUserId, it } from "@flex/testing";
-import nock from "nock";
+import { it } from "@flex/testing";
+import { userId } from "@tests/fixtures";
 import { describe, expect } from "vitest";
 
-import { handler } from "./get";
+import { handler } from "./get.private";
 
-describe("GET /v1/identity/:service", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
+describe("GET /v1/identity/:service [private]", () => {
+  const serviceName = "test-service";
+  const serviceId = "test-service-id";
+  const endpoint = `/identity/${serviceName}`;
 
-  const service = "test-service";
-  const userId = createUserId("test-pairwise-id");
+  const identity = { serviceId, serviceName };
 
-  const event = {
-    pathParameters: { service },
-  };
+  it("returns 200 with identity when an identity link exists", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
 
-  const foundServiceIdentity = {
-    serviceId: "existing-id",
-    serviceName: "test-service",
-  };
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        userId,
+        headers: { "User-Id": userId },
+        params: { service: serviceName },
+      }),
+      sdk.context(),
+    );
 
-  describe("response", () => {
-    it("returns 200 when a service identity exists", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, foundServiceIdentity);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: true });
-    });
-
-    it("returns 200 with linked false when identity does not exist (404)", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(404);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: false });
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(identity);
   });
 
-  describe("errors", () => {
-    it("returns 502 when the upstream service returns a 500", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(500);
+  it("returns 404 when an identity link does not exist", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        userId,
+        headers: { "User-Id": userId },
+        params: { service: serviceName },
+      }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(404);
+  });
+
+  it("returns 502 when the UDP identity link integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.get(endpoint, {
+        userId,
+        headers: { "User-Id": userId },
+        params: { service: serviceName },
+      }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/udp/src/handlers/v1/identity/[service]/get.private.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/get.private.ts
@@ -1,23 +1,21 @@
 import { route } from "@domain";
-import { UserId } from "@flex/utils";
+import type { UserId } from "@flex/utils";
+import { getServiceIdentityLink } from "@services/identity";
 import createHttpError from "http-errors";
 import status from "http-status";
-
-import { getServiceIdentityLink } from "../../../../services/identity";
 
 export const handler = route(
   "GET /v1/identity/:service [private]",
   async ({ headers }) => {
+    // TODO: SDK auth alias
     const userId = headers.userId as UserId;
-    const linked = await getServiceIdentityLink(userId);
 
-    if (!linked) {
+    const identity = await getServiceIdentityLink(userId);
+
+    if (!identity) {
       throw new createHttpError.NotFound();
     }
 
-    return {
-      status: status.OK,
-      data: linked,
-    };
+    return { status: status.OK, data: identity };
   },
 );

--- a/domains/udp/src/handlers/v1/identity/[service]/get.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/get.test.ts
@@ -1,78 +1,66 @@
-import { createUserId, it } from "@flex/testing";
-import nock from "nock";
+import { it } from "@flex/testing";
+import { userId } from "@tests/fixtures";
 import { describe, expect } from "vitest";
 
 import { handler } from "./get";
 
 describe("GET /v1/identity/:service", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
+  const serviceName = "test-service";
+  const serviceId = "test-service-id";
+  const endpoint = `/identity/${serviceName}`;
 
-  const service = "test-service";
-  const userId = createUserId("test-pairwise-id");
+  const identity = { serviceId, serviceName };
 
-  const event = {
-    pathParameters: { service },
-  };
+  it("returns 200 with linked status as true when an identity link exists", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(200, identity);
 
-  const foundServiceIdentity = {
-    serviceId: "existing-id",
-    serviceName: "test-service",
-  };
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-  describe("response", () => {
-    it("returns 200 when a service identity exists", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(200, foundServiceIdentity);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: true });
-    });
-
-    it("returns 200 with linked false when identity does not exist (404)", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(404);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(JSON.parse(result.body)).toStrictEqual({ linked: false });
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ linked: true });
   });
 
-  describe("errors", () => {
-    it("returns 502 when the upstream service returns a 500", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get(`/gateways/udp/v1/identity/${service}`)
-        .matchHeader("User-Id", userId)
-        .reply(500);
+  it("returns 200 with linked status as false when an identity link does not exist", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(404);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.create(event),
-        context.create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
 
-      expect(result.statusCode).toBe(502);
-    });
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ linked: false });
+  });
+
+  it("returns 502 when the UDP identity link integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get(`/identity/${serviceName}`, { headers: { "User-Id": userId } })
+      .reply(500);
+
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, params: { service: serviceName } }),
+      sdk.context(),
+    );
+
+    expect(result.statusCode).toBe(502);
   });
 });

--- a/domains/udp/src/handlers/v1/identity/[service]/get.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/get.ts
@@ -1,21 +1,16 @@
 import { route } from "@domain";
-import { UserId } from "@flex/utils";
+import type { UserId } from "@flex/utils";
+import { getServiceIdentityLink } from "@services/identity";
 import status from "http-status";
 
-import { getServiceIdentityLink } from "../../../../services/identity";
-
 export const handler = route("GET /v1/identity/:service", async ({ auth }) => {
-  const data = await getServiceIdentityLink(auth.pairwiseId as UserId);
+  // TODO: SDK auth alias
+  const userId = auth.pairwiseId as UserId;
 
-  if (!data) {
-    return {
-      status: status.OK,
-      data: { linked: false },
-    };
-  }
+  const identity = await getServiceIdentityLink(userId);
 
   return {
     status: status.OK,
-    data: { linked: true },
+    data: { linked: Boolean(identity) },
   };
 });

--- a/domains/udp/src/handlers/v1/users/me/get.test.ts
+++ b/domains/udp/src/handlers/v1/users/me/get.test.ts
@@ -1,12 +1,6 @@
-import { createUserId, it } from "@flex/testing";
-import type {
-  CreateNotificationPreferencesResponse,
-  UpdateNotificationPreferencesOutboundResponse,
-} from "@schemas/notifications";
-import type { CreateUserRequest } from "@schemas/user";
-import { createPushId } from "@tests/fixtures";
+import { it } from "@flex/testing";
+import { pushId, userId } from "@tests/fixtures";
 import { getPushId } from "@utils/get-push-id";
-import nock from "nock";
 import { describe, expect, vi } from "vitest";
 
 import { handler } from "./get";
@@ -14,151 +8,150 @@ import { handler } from "./get";
 vi.mock("@utils/get-push-id");
 
 describe("GET /v1/users/me", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
   const endpoint = "/users/me";
 
   const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
 
-  const userId = createUserId("test-pairwise-id");
-  const pushId = createPushId();
+  const user = { userId, pushId };
 
-  const user: CreateUserRequest = { userId, pushId };
+  it("returns 200 with user profile", async ({ http, sdk }) => {
+    const notifications = { consentStatus: "accepted", pushId };
 
-  const foundNotificationPreferences: UpdateNotificationPreferencesOutboundResponse =
-    {
-      consentStatus: "accepted",
-      pushId: createPushId("existing-id"),
-    };
+    http
+      .gateway("udp")
+      .get("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(200, notifications);
 
-  const createdNotificationPreferences: CreateNotificationPreferencesResponse =
-    {
-      consentStatus: "unknown",
-      pushId: createPushId("created-id"),
-    };
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-  describe("response", () => {
-    it("returns 200 when user profile exists", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(200, foundNotificationPreferences);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context
-          .withSecret(secrets) // pragma: allowlist secret
-          .create(),
-      );
-
-      expect(vi.mocked(getPushId)).toHaveBeenCalledExactlyOnceWith(
-        userId,
-        secrets.udpNotificationSecret,
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(result.headers).toStrictEqual({
-        "Content-Type": "application/json",
-      });
-      expect(JSON.parse(result.body)).toStrictEqual({
-        userId,
-        notifications: foundNotificationPreferences,
-      });
-    });
-
-    it("returns 200 and creates user when user profile does not exist", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(404);
-
-      api.post("/gateways/udp/v1/users", user).reply(204);
-
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(200, createdNotificationPreferences);
-
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(result.headers).toStrictEqual({
-        "Content-Type": "application/json",
-      });
-      expect(JSON.parse(result.body)).toStrictEqual({
-        userId,
-        notifications: createdNotificationPreferences,
-      });
-    });
+    expect(vi.mocked(getPushId)).toHaveBeenCalledExactlyOnceWith(
+      userId,
+      secrets.udpNotificationSecret,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ userId, notifications });
   });
 
-  describe("errors", () => {
-    it("returns 502 when notifications lookup fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(500);
+  it("returns 200 and creates a user when the user profile does not exist", async ({
+    http,
+    sdk,
+  }) => {
+    const notifications = { consentStatus: "unknown", pushId };
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
+    http
+      .gateway("udp")
+      .get("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(404);
+    http.gateway("udp").post("/users", { body: user }).reply(204);
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(200, notifications);
 
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-    it("returns 502 when user creation fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(404);
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ userId, notifications });
+  });
 
-      api.post("/gateways/udp/v1/users", user).reply(500);
+  it("returns 502 when the UDP get notifications integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(500);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
+  });
 
-    it("returns 502 when notifications creation fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .get("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(404);
+  it("returns 502 when the UDP create user integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(404);
+    http.gateway("udp").post("/users", { body: user }).reply(500);
 
-      api.post("/gateways/udp/v1/users", user).reply(204);
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
 
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(500);
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
+  });
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
+  it("returns 502 when the UDP create notifications integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .get("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(404);
+    http.gateway("udp").post("/users", { body: user }).reply(204);
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(500);
 
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    const result = await handler(
+      sdk.event.get(endpoint, { userId }),
+      sdk.context({ secrets }),
+    );
+
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
   });
 });

--- a/domains/udp/src/handlers/v1/users/me/get.ts
+++ b/domains/udp/src/handlers/v1/users/me/get.ts
@@ -1,5 +1,5 @@
 import { route, routeContext } from "@domain";
-import { UserId } from "@flex/utils";
+import type { UserId } from "@flex/utils";
 import type {
   GetNotificationPreferencesResponse,
   PushId,
@@ -13,7 +13,7 @@ const context = routeContext<"GET /v1/users/me">;
 export const handler = route(
   "GET /v1/users/me",
   async ({ auth, logger, resources }) => {
-    // TODO: Add to SDK auth or keep alias for this domain only?
+    // TODO: SDK auth alias
     const userId = auth.pairwiseId as UserId;
 
     const pushId = getPushId(userId, resources.udpNotificationSecret);

--- a/domains/udp/src/handlers/v1/users/me/notifications/patch.test.ts
+++ b/domains/udp/src/handlers/v1/users/me/notifications/patch.test.ts
@@ -1,11 +1,6 @@
-import { createUserId, it } from "@flex/testing";
-import type {
-  UpdateNotificationPreferencesOutboundResponse,
-  UpdateNotificationPreferencesRequest,
-} from "@schemas/notifications";
-import { createPushId } from "@tests/fixtures";
+import { it } from "@flex/testing";
+import { pushId, userId } from "@tests/fixtures";
 import { getPushId } from "@utils/get-push-id";
-import nock from "nock";
 import { describe, expect, vi } from "vitest";
 
 import { handler } from "./patch";
@@ -13,90 +8,80 @@ import { handler } from "./patch";
 vi.mock("@utils/get-push-id");
 
 describe("PATCH /v1/users/me/notifications", () => {
-  const api = nock("https://execute-api.eu-west-2.amazonaws.com");
   const endpoint = "/users/me/notifications";
 
-  const userId = createUserId("test-pairwise-id");
   const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
 
-  const body: UpdateNotificationPreferencesRequest = {
-    consentStatus: "accepted",
-  };
-  const updatedNotifications: UpdateNotificationPreferencesOutboundResponse = {
-    consentStatus: "accepted",
-    pushId: createPushId("updated-id"),
-  };
-
-  describe("request validation", () => {
-    it.for([
-      {
-        body: { consentStatus: "yes" },
-        reason: "contains invalid consent status",
-      },
-      { body: {}, reason: "is empty" },
-    ])(
-      "returns 400 when payload $reason",
-      async ({ body }, { context, privateGatewayEventWithAuthorizer }) => {
-        const result = await handler(
-          privateGatewayEventWithAuthorizer.patch(endpoint, { body }),
-          context.withSecret(secrets).create(), // pragma: allowlist secret
-        );
-
-        expect(result).toStrictEqual({
-          statusCode: 400,
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ message: "Invalid request body" }),
-        });
-      },
+  it.for([
+    { body: {}, reason: "is empty" },
+    {
+      body: { consentStatus: "yes" },
+      reason: "contains invalid consent status",
+    },
+  ])("returns 400 when payload $reason", async ({ body }, { sdk }) => {
+    const result = await handler(
+      sdk.event.patch(endpoint, { userId, body }),
+      sdk.context({ secrets }),
     );
+
+    expect(result.statusCode).toBe(400);
+    expect(JSON.parse(result.body)).toStrictEqual({
+      message: "Invalid request body",
+    });
   });
 
-  describe("response", () => {
-    it("returns 200 when notifications are updated", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(200, updatedNotifications);
+  it("returns 200 with updated notifications", async ({ http, sdk }) => {
+    const notifications = { consentStatus: "accepted", pushId };
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.patch(endpoint, { body }),
-        context
-          .withSecret(secrets) // pragma: allowlist secret
-          .create(),
-      );
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(200, notifications);
 
-      expect(vi.mocked(getPushId)).toHaveBeenCalledExactlyOnceWith(
+    const result = await handler(
+      sdk.event.patch(endpoint, {
         userId,
-        secrets.udpNotificationSecret,
-      );
+        body: { consentStatus: "accepted" },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(200);
-      expect(result.headers).toStrictEqual({
-        "Content-Type": "application/json",
-      });
-      expect(JSON.parse(result.body)).toStrictEqual(updatedNotifications);
-    });
+    expect(vi.mocked(getPushId)).toHaveBeenCalledExactlyOnceWith(
+      userId,
+      secrets.udpNotificationSecret,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual(notifications);
   });
 
-  describe("errors", () => {
-    it("returns 502 when notifications update fails", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      api
-        .post("/gateways/udp/v1/notifications")
-        .matchHeader("requesting-service-user-id", userId)
-        .reply(500);
+  it("returns 502 when the UDP create notifications integration fails", async ({
+    http,
+    sdk,
+  }) => {
+    http
+      .gateway("udp")
+      .post("/notifications", {
+        headers: {
+          "requesting-service": "app",
+          "requesting-service-user-id": userId,
+        },
+      })
+      .reply(500);
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.patch(endpoint, { body }),
-        context.withSecret(secrets).create(), // pragma: allowlist secret
-      );
+    const result = await handler(
+      sdk.event.patch(endpoint, {
+        userId,
+        body: { consentStatus: "accepted" },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result).toStrictEqual({ statusCode: 502, body: "" });
-    });
+    expect(result.statusCode).toBe(502);
+    expect(result.body).toBe("");
   });
 });

--- a/domains/udp/src/handlers/v1/users/me/notifications/patch.ts
+++ b/domains/udp/src/handlers/v1/users/me/notifications/patch.ts
@@ -4,7 +4,7 @@ import type {
   PushId,
   UpdateNotificationPreferencesOutboundResponse,
 } from "@schemas/notifications";
-import { getPushId } from "@utils";
+import { getPushId } from "@utils/get-push-id";
 import createHttpError from "http-errors";
 
 const context = routeContext<"PATCH /v1/users/me/notifications">;
@@ -12,7 +12,7 @@ const context = routeContext<"PATCH /v1/users/me/notifications">;
 export const handler = route(
   "PATCH /v1/users/me/notifications",
   async ({ auth, resources }) => {
-    // TODO: Add to SDK auth or keep alias for this domain only?
+    // TODO: SDK auth alias
     const userId = auth.pairwiseId as UserId;
 
     const notifications = await updateNotifications(

--- a/domains/udp/src/handlers/v1/users/push-id/get.private.test.ts
+++ b/domains/udp/src/handlers/v1/users/push-id/get.private.test.ts
@@ -1,5 +1,5 @@
-import { createUserId, it } from "@flex/testing";
-import { createPushId } from "@tests/fixtures";
+import { it } from "@flex/testing";
+import { pushId, userId } from "@tests/fixtures";
 import { getPushId } from "@utils/get-push-id";
 import { describe, expect, vi } from "vitest";
 
@@ -7,60 +7,37 @@ import { handler } from "./get.private";
 
 vi.mock("@utils/get-push-id");
 
-describe("GET /v1/users/push-id", () => {
-  const endpoint = "/v1/users/push-id";
+describe("GET /v1/users/push-id [private]", () => {
+  const endpoint = "/users/push-id";
+
   const secrets = { udpNotificationSecret: "test-notification-secret" }; // pragma: allowlist secret
 
-  const userId = createUserId("test-pairwise-id");
-  const pushId = createPushId("mocked-push-id");
+  it("returns 200 with UNS push ID", async ({ sdk }) => {
+    vi.mocked(getPushId).mockReturnValue(pushId);
 
-  describe("response", () => {
-    it("returns 200 and the uns user pushId", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(getPushId).mockReturnValue(pushId);
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, headers: { "User-Id": userId } }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint, {
-          headers: { "User-Id": userId },
-        }),
-        context.withSecret(secrets).create(),
-      );
-
-      expect(vi.mocked(getPushId)).toHaveBeenCalledWith(
-        userId,
-        secrets.udpNotificationSecret,
-      );
-
-      expect(result.statusCode).toBe(200);
-      expect(result.headers).toStrictEqual({
-        "Content-Type": "application/json",
-      });
-
-      expect(JSON.parse(result.body)).toStrictEqual({
-        pushId,
-      });
-    });
+    expect(vi.mocked(getPushId)).toHaveBeenCalledExactlyOnceWith(
+      userId,
+      secrets.udpNotificationSecret,
+    );
+    expect(result.statusCode).toBe(200);
+    expect(JSON.parse(result.body)).toStrictEqual({ pushId });
   });
 
-  describe("errors", () => {
-    it("returns 500 when pushId generation throws an error", async ({
-      context,
-      privateGatewayEventWithAuthorizer,
-    }) => {
-      vi.mocked(getPushId).mockImplementation(() => {
-        throw new Error("User ID and secret key cannot be empty");
-      });
+  it("returns 500 when push ID generation fails", async ({ sdk }) => {
+    vi.mocked(getPushId).mockThrow(
+      new Error("User ID and secret key cannot be empty"),
+    );
 
-      const result = await handler(
-        privateGatewayEventWithAuthorizer.get(endpoint, {
-          headers: { "User-Id": userId },
-        }),
-        context.withSecret(secrets).create(),
-      );
+    const result = await handler(
+      sdk.event.get(endpoint, { userId, headers: { "User-Id": userId } }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(500);
-    });
+    expect(result.statusCode).toBe(500);
   });
 });

--- a/domains/udp/src/handlers/v1/users/push-id/get.private.ts
+++ b/domains/udp/src/handlers/v1/users/push-id/get.private.ts
@@ -1,20 +1,19 @@
 import { route } from "@domain";
-import { UserId } from "@flex/utils";
-import { getPushId } from "@utils";
+import type { UserId } from "@flex/utils";
+import { getPushId } from "@utils/get-push-id";
 import status from "http-status";
 
 export const handler = route(
   "GET /v1/users/push-id [private]",
   // eslint-disable-next-line @typescript-eslint/require-await
   async ({ headers, resources }) => {
+    // TODO: SDK auth alias
     const userId = headers.userId as UserId;
     const pushId = getPushId(userId, resources.udpNotificationSecret);
 
     return {
       status: status.OK,
-      data: {
-        pushId,
-      },
+      data: { pushId },
     };
   },
 );

--- a/domains/udp/src/services/identity.ts
+++ b/domains/udp/src/services/identity.ts
@@ -4,7 +4,7 @@ import {
   CreateServiceIdentityLinkRequest,
   DeleteServiceIdentityLinkResponse,
   GetServiceIdentityLinkResponse,
-} from "@schemas";
+} from "@schemas/identity";
 import createHttpError from "http-errors";
 
 type PostRoute = "POST /v1/identity/:service/:id";

--- a/domains/udp/src/tests/fixtures.ts
+++ b/domains/udp/src/tests/fixtures.ts
@@ -1,5 +1,8 @@
+import { createUserId } from "@flex/testing";
 import type { PushId } from "@schemas/notifications";
 
-export const createPushId = (id = "test-notification-id") => id as PushId;
+export { createUserId };
+export const createPushId = (id = "test-push-id") => id as PushId;
 
+export const userId = createUserId();
 export const pushId = createPushId();

--- a/domains/udp/src/utils/__mocks__/get-push-id.ts
+++ b/domains/udp/src/utils/__mocks__/get-push-id.ts
@@ -1,4 +1,4 @@
-import type { PushId } from "@schemas/notifications";
+import { pushId } from "@tests/fixtures";
 import { vi } from "vitest";
 
-export const getPushId = vi.fn(() => "test-notification-id" as PushId);
+export const getPushId = vi.fn(() => pushId);

--- a/domains/udp/src/utils/get-push-id.test.ts
+++ b/domains/udp/src/utils/get-push-id.test.ts
@@ -1,5 +1,4 @@
-import { it } from "@flex/testing";
-import { createUserId } from "@flex/testing";
+import { createUserId, it } from "@flex/testing";
 import { describe, expect } from "vitest";
 
 import { getPushId } from "./get-push-id";

--- a/domains/udp/tsconfig.json
+++ b/domains/udp/tsconfig.json
@@ -4,11 +4,10 @@
   "compilerOptions": {
     "paths": {
       "@domain": ["./domain.config.ts"],
-      "@schemas": ["./src/schemas/index.ts"],
       "@schemas/*": ["./src/schemas/*"],
-      "@utils": ["./src/utils/index.ts"],
-      "@utils/*": ["./src/utils/*"],
-      "@tests/fixtures": ["./src/tests/fixtures.ts"]
+      "@services/*": ["./src/services/*"],
+      "@tests/fixtures": ["./src/tests/fixtures.ts"],
+      "@utils/*": ["./src/utils/*"]
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

- Add path alias to improve imports
- Update UDP test suites to use `http`/`sdk` fixtures
- Fix misconfigured test suites (test referencing incorrect handler)
- Add test cases for uncovered branches
- Clean up test fixture usage for domain-only helpers (createPushId/createUserId with userId/pushId mocks)
- Remove unused module mocks from tests (`@utils/get-push-id`, not needed for these handler tests)

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-240

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (code change that does not add functionality or fix a bug)
- [x] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined
