### PR TITLE
Fix/expired token sg

### DIFF
--- a/libs/flex-fetch/src/sigv4/index.test.ts
+++ b/libs/flex-fetch/src/sigv4/index.test.ts
@@ -258,13 +258,26 @@ describe("createSigv4FetchWithCredentials", () => {
       ).toBe(true);
     });
 
-    it("returns false when expiration is in the future", () => {
+    it("returns true when expiration is within the 5-minute buffer", () => {
+      const isExpired = getIsExpired(
+        "arn:aws:iam::601500000000:role/near-expiry",
+      );
+      expect(
+        isExpired({
+          accessKeyId: "k",
+          secretAccessKey: "s",
+          expiration: new Date(Date.now() + 299_000),
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when expiration is more than 5 minutes away", () => {
       const isExpired = getIsExpired("arn:aws:iam::602000000000:role/valid");
       expect(
         isExpired({
           accessKeyId: "k",
           secretAccessKey: "s",
-          expiration: new Date(Date.now() + 10_000),
+          expiration: new Date(Date.now() + 600_000),
         }),
       ).toBe(false);
     });
@@ -285,30 +298,17 @@ describe("createSigv4FetchWithCredentials", () => {
       return call[2] as (creds: AwsCredentialIdentity) => boolean;
     }
 
-    it("returns true when credentials expire within the 5-minute buffer", () => {
+    it("returns true when credentials have an expiry", () => {
       const requiresRefresh = getRequiresRefresh(
-        "arn:aws:iam::701000000000:role/needs-refresh",
+        "arn:aws:iam::701000000000:role/has-expiry",
       );
       expect(
         requiresRefresh({
           accessKeyId: "k",
           secretAccessKey: "s",
-          expiration: new Date(Date.now() + 299_000),
+          expiration: new Date(Date.now() + 3_600_000),
         }),
       ).toBe(true);
-    });
-
-    it("returns false when credentials expire beyond the 5-minute buffer", () => {
-      const requiresRefresh = getRequiresRefresh(
-        "arn:aws:iam::702000000000:role/fresh",
-      );
-      expect(
-        requiresRefresh({
-          accessKeyId: "k",
-          secretAccessKey: "s",
-          expiration: new Date(Date.now() + 600_000),
-        }),
-      ).toBe(false);
     });
 
     it("returns false when expiration is undefined", () => {

--- a/libs/flex-fetch/src/sigv4/index.ts
+++ b/libs/flex-fetch/src/sigv4/index.ts
@@ -75,19 +75,20 @@ export function createSigv4FetchWithCredentials(
     const loggingProvider = async () => {
       const creds = await provider();
       logger.info("STS credentials refreshed", {
-        expiration: creds.expiration,
+        expiration: creds.expiration?.toISOString(),
       });
       return creds;
     };
 
+    // isExpired: refresh when less than 5 minutes remain, giving a buffer before the 1h STS TTL.
+    // requiresRefresh: return true whenever the credential has an expiry — prevents memoize from
+    // marking it as a permanent constant and skipping the isExpired check on subsequent calls.
     credentials = memoize(
       loggingProvider,
       (creds) =>
         creds.expiration !== undefined &&
-        creds.expiration.getTime() < Date.now(),
-      (creds) =>
-        creds.expiration !== undefined &&
         creds.expiration.getTime() - Date.now() < 300_000,
+      (creds) => creds.expiration !== undefined,
     );
 
     cachedCredentialProviders.set(cacheKey, credentials);

--- a/tests/performance/scenarios/user-get.yml
+++ b/tests/performance/scenarios/user-get.yml
@@ -31,7 +31,7 @@ scenarios:
     beforeScenario: pickUserJwt
     flow:
       - get:
-          url: "/app/udp/v1/users"
+          url: "/app/udp/v1/users/me"
           headers:
             Authorization: "Bearer {{ jwt }}"
           expect:

--- a/tests/performance/scenarios/user-upsert.yml
+++ b/tests/performance/scenarios/user-upsert.yml
@@ -31,7 +31,7 @@ scenarios:
     beforeScenario: pickUserJwt
     flow:
       - get:
-          url: "/app/udp/v1/users"
+          url: "/app/udp/v1/users/me"
           headers:
             Authorization: "Bearer {{ jwt }}"
           expect:

--- a/tests/performance/soak.config.yml
+++ b/tests/performance/soak.config.yml
@@ -4,9 +4,9 @@ config:
     timeout: 30
   phases:
     - name: soak
-      duration: 1800
-      arrivalRate: 15
-      maxVusers: 50
+      duration: 4500
+      arrivalRate: 1
+      maxVusers: 1
   plugins:
     publish-metrics:
       - type: cloudwatch


### PR DESCRIPTION
# Pull Request

## Description

The bug waas in how memoize was being used. Memoize takes three args: a provider, an `isExpired` predicate and `requiresRefresh` predicate. 

The memoize behaviour is:

```js
if (requiresRefresh && !requiresRefresh(resolved)) {
  isConstant = true; // <- this credential never needs checking again
  return resolved;
}
if (isExpired(resolved)) {
  await coalesceProvider(); // <- only reached if isConstant is false
  return resolved;
}
```

The `isExpired` check never reached again. The previous fix had written `requiresRefresh` as

```ts
(creds) => creds.expiration !== undefined && creds.expiration.getTime() - Date.now() < 300_000
```

which returns true only when less than 5 minutes remain. On a second request, it returned false. `memoize` interpreted that as mark this credential as constant. From then, the 1-hour STS token was returned forever with no expiry checks.

The fix changes:

`requiresRefresh` now returns true whenever the credential has an expiry field at all, telling `memoize` not to mark this as constant and to keep evaluating `isExpired` field. 

`isExpired` has a 5 minute buffer, triggering a refresh when less than 5 minutes remain before the token expires.


## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

Soak test ran for 75 minutes against a single lambda function (vusers set to 1) and observed for calls to `STS credentials refreshed`. 

<img width="619" height="125" alt="Screenshot 2026-06-04 at 14 16 47" src="https://github.com/user-attachments/assets/80744fc9-3551-4172-8e87-05bcfa6666fc" />
