### PR TITLE
feat(tests): add WAF E2E bypass header for CI/CD pipeline

### DIFF
--- a/libs/testing/src/config/env.ts
+++ b/libs/testing/src/config/env.ts
@@ -10,6 +10,11 @@ export const e2eEnvSchema = z.object({
     VALID: z.string(),
     INVALID: z.string(),
   }),
+  E2E_BYPASS_TOKEN: z
+    .string()
+    .describe(
+      "Secret token for the x-flex-e2e-bypass WAF header to skip IP reputation blocking",
+    ),
   STAGE: z
     .string()
     .optional()

--- a/libs/testing/src/extend/it.e2e.ts
+++ b/libs/testing/src/extend/it.e2e.ts
@@ -10,11 +10,13 @@ import { E2EEnv } from "../config/env";
 import { createApi } from "../fixtures";
 import { getStubTokenGenerator } from "../fixtures/StubTokenGenerator";
 
+const E2E_BYPASS_HEADER = "x-flex-e2e-bypass";
+
 interface Fixtures {
   cloudfront: ReturnType<typeof createApi>;
   privateGateway: ReturnType<typeof createApi>;
   authSub: string | undefined;
-  authHeader: { Authorization: string };
+  authHeader: { Authorization: string; [E2E_BYPASS_HEADER]: string };
 }
 
 let stubGeneratorPromise: ReturnType<typeof getStubTokenGenerator> | undefined;
@@ -58,6 +60,10 @@ export const extendIt = () =>
     authSub: undefined,
     authHeader: async ({ task, authSub }, use) => {
       const token = await tokenForFile(task.file.filepath, authSub);
-      await use({ Authorization: `Bearer ${token}` });
+      const { E2E_BYPASS_TOKEN } = inject("e2eEnv");
+      await use({
+        Authorization: `Bearer ${token}`,
+        [E2E_BYPASS_HEADER]: E2E_BYPASS_TOKEN,
+      });
     },
   });

--- a/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
+++ b/platform/infra/flex/src/constructs/cloudfront/flex-cloudfront.ts
@@ -48,6 +48,7 @@ interface FlexCloudfrontProps extends AlarmActionProps {
 
 export class FlexCloudfront extends Construct {
   public readonly distribution: Distribution;
+  public readonly e2eBypassSecret: Secret;
 
   constructor(
     scope: Construct,
@@ -79,6 +80,20 @@ export class FlexCloudfront extends Construct {
     const viewerRequestFunction = flexCloudfrontFunction.function;
 
     const cert = Certificate.fromCertificateArn(this, "flexDnsCert", certArn);
+
+    this.e2eBypassSecret = new Secret(this, "E2EBypassSecret", {
+      secretName: `/${envConfig.stage}/flex-secret/e2e-bypass`,
+      generateSecretString: {
+        excludePunctuation: true,
+        passwordLength: 32,
+      },
+      replicaRegions: [{ region: "eu-west-2" }],
+    });
+    applyCheckovSkip(
+      this.e2eBypassSecret,
+      "CKV_AWS_149",
+      "Using AWS managed keys is fine in this case and lets us keep the pattern consistent with origin-verify-secret",
+    );
 
     const webAcl = new CfnWebACL(this, "CfWebAcl", {
       scope: "CLOUDFRONT",
@@ -135,8 +150,28 @@ export class FlexCloudfront extends Construct {
           },
         },
         {
-          name: "AWSManagedRulesAmazonIpReputationList",
+          name: "BypassForE2ETests",
           priority: 2,
+          action: { allow: {} },
+          statement: {
+            byteMatchStatement: {
+              fieldToMatch: {
+                singleHeader: { Name: "x-flex-e2e-bypass" },
+              },
+              positionalConstraint: "EXACTLY",
+              searchString: this.e2eBypassSecret.secretValue.unsafeUnwrap(),
+              textTransformations: [{ priority: 0, type: "NONE" }],
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: "BypassForE2ETests",
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: "AWSManagedRulesAmazonIpReputationList",
+          priority: 3,
           overrideAction: { none: {} },
           statement: {
             managedRuleGroupStatement: {
@@ -152,7 +187,7 @@ export class FlexCloudfront extends Construct {
         },
         {
           name: "RateLimit",
-          priority: 3,
+          priority: 4,
           action: { block: {} },
           statement: {
             rateBasedStatement: {

--- a/platform/infra/flex/src/stacks/global.ts
+++ b/platform/infra/flex/src/stacks/global.ts
@@ -173,7 +173,7 @@ export class FlexGlobalStack extends BaseStack {
       "eu-west-2",
     );
 
-    new FlexCloudfront(this, "Cloudfront", {
+    const cloudfront = new FlexCloudfront(this, "Cloudfront", {
       certArn: cert.certificateArn,
       secretHeaderArn,
       domainName,
@@ -186,6 +186,10 @@ export class FlexGlobalStack extends BaseStack {
 
     new CfnOutput(this, "FlexApiUrl", {
       value: `https://${subdomainName ?? domainName}`,
+    });
+
+    new CfnOutput(this, "E2EBypassSecretArn", {
+      value: cloudfront.e2eBypassSecret.secretArn,
     });
   }
 }

--- a/tests/e2e/src/setup.global.ts
+++ b/tests/e2e/src/setup.global.ts
@@ -1,3 +1,4 @@
+import { getSecret } from "@aws-lambda-powertools/parameters/secrets";
 import {
   BaseTokenGenerator,
   e2eEnvSchema,
@@ -9,6 +10,16 @@ import { getStackOutputs, sanitiseStageName } from "@flex/utils";
 import { config } from "dotenv";
 
 config({ quiet: true });
+
+async function getE2eBypassToken(stage: string): Promise<string> {
+  const token = await getSecret(`/${stage}/flex-secret/e2e-bypass`);
+
+  if (!token) {
+    throw new Error(`E2E bypass secret not found for stage "${stage}"`);
+  }
+
+  return token as string;
+}
 
 export default async function setup({
   provide,
@@ -57,8 +68,10 @@ export default async function setup({
     privateGatewayUrl = PrivateGatewayUrl;
   }
 
-  const jwtClient = await getJwtClient(stage);
-  const validJwtToken = await jwtClient.getToken();
+  const [validJwtToken, e2eBypassToken] = await Promise.all([
+    getJwtClient(stage).then((c) => c.getToken()),
+    getE2eBypassToken(stage),
+  ]);
 
   provide(
     "e2eEnv",
@@ -70,6 +83,7 @@ export default async function setup({
         VALID: validJwtToken,
         INVALID: invalidJwt,
       },
+      E2E_BYPASS_TOKEN: e2eBypassToken,
     }),
   );
 }


### PR DESCRIPTION
## Description

GitHub Actions runners spin up on Azure public IPs that are frequently flagged by AWS's IP reputation list (`AWSManagedRulesAmazonIpReputationList`). When an E2E runner hits a flagged IP, the CloudFront WAF blocks the request with a 403 before it reaches API Gateway, causing intermittent pipeline failures.

Add a `BypassForE2ETests` WAF rule at priority 2 (after CommonRuleSet and KnownBadInputs, before IP reputation) that allows requests carrying a `x-flex-e2e-bypass` header. The expected value is a per-stage 32-character random token stored in Secrets Manager. The E2E test setup discovers the secret via CloudFormation output and injects it into the `authHeader` fixture — zero test code changes required.

IP reputation and rate limiting still apply to all non-E2E traffic. CommonRuleSet and KnownBadInputs still run against E2E requests. The rule exists in all environments (including production) for consistency — no CI/CD pipeline runs E2E tests in production, so the rule is inert there.

**Related Issue:** [FLEX-352](https://gdsgovukagents.atlassian.net/browse/FLEX-352)

## How Has This Been Tested?

- [x] `cdk synth` — confirmed `BypassForE2ETests` rule appears at priority 2 with correct byte-match statement
- [x] TypeScript type-checks pass across all affected packages (`@platform/flex`, `@flex/testing`, `@flex/e2e`)
- [x] Lint passes with zero warnings
- [ ] CI/CD ephemeral environment — verify E2E tests pass without 403 flakiness in the PR pipeline

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have updated/added all necessary tests
- [x] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have refactored my code to be more readable, maintainable and removed duplications.
- [x] I have added guards around invalid inputs and edge cases such as nulls and undefined


[FLEX-352]: https://gdsgovukagents.atlassian.net/browse/FLEX-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ