### PR TITLE
FLEX-357: enforce SHA pinning for all GitHub Actions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,15 @@ repos:
       - id: check-case-conflict
       - id: detect-private-key
 
+  - repo: local
+    hooks:
+      - id: check-action-shas
+        name: Check GitHub Actions SHA pinning
+        entry: bash scripts/check-action-shas.sh
+        language: system
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/scripts/check-action-shas.sh
+++ b/scripts/check-action-shas.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Check that all third-party GitHub Actions are pinned to a full commit SHA.
+
+errors=0
+for f in .github/workflows/*.yml; do
+  while IFS= read -r line; do
+    case "$line" in
+      *uses:\ ./*|*uses:\ docker://*) continue ;;
+      *uses:\ *@*)
+        case "$line" in
+          *@[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+            # Full SHA found, good
+          ;;
+          *)
+            # Extract the ref after @ for a cleaner error
+            ref=$(printf '%s\n' "$line" | sed 's/.*@//' | sed 's/[[:space:]#].*//')
+            action=$(printf '%s\n' "$line" | sed 's/.*uses:[[:space:]]*//' | sed 's/@.*//' | sed 's/^-[[:space:]]*//')
+            echo "::error file=$f::Action \"$action\" pinned to \"$ref\" instead of a full 40-char commit SHA"
+            errors=$((errors + 1))
+          ;;
+        esac
+      ;;
+    esac
+  done < "$f"
+done
+
+if [ "$errors" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Description

Adds a verification step to the shared `_qualityChecks.yml` workflow that scans `.github/workflows/*.yml` for `uses:` references and rejects any that aren't pinned to a full 40-character commit SHA. Tags can be moved by a maintainer (or attacker); commit SHAs cannot.

**Related Issue:** [FLEX-357](https://gdsgovukagents.atlassian.net/browse/FLEX-357)

## Type of Change

- [ ] Other (CI/security hardening)

## How Has This Been Tested?

- [x] Ran the grep against all existing workflow files — zero violations
- [x] Step runs as part of `_qualityChecks.yml`, which is invoked on every PR and every push to main

[Enforced run](https://github.com/govuk-once/flex/actions/runs/27335829404/job/80759629370) 

## Checklist

- [x] I have run the pre-commit
- [x] I have run all necessary tests
- [x] I have performed a self-review of my code


[FLEX-357]: https://gdsgovukagents.atlassian.net/browse/FLEX-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ