### PR TITLE
FLEX-000 fix: Reuse MonitoringSubscription ID from previous deployment

### DIFF
--- a/platform/infra/flex/src/stacks/global.ts
+++ b/platform/infra/flex/src/stacks/global.ts
@@ -12,6 +12,7 @@ import {
   AllowedMethods,
   CachePolicy,
   CfnDistribution,
+  CfnMonitoringSubscription,
   Distribution,
   FunctionEventType,
   OriginRequestPolicy,
@@ -411,6 +412,12 @@ export class FlexGlobalStack extends BaseStack {
     });
     const cfnDistribution = distribution.node.defaultChild as CfnDistribution;
     cfnDistribution.overrideLogicalId("CloudfrontDistributionD69C1995");
+    const cfnMonitoringSubscription = distribution.node.findChild(
+      "MonitoringSubscription",
+    ) as CfnMonitoringSubscription;
+    cfnMonitoringSubscription.overrideLogicalId(
+      "CloudfrontDistributionMonitoringSubscription4785C264",
+    );
 
     new CloudFrontAlarms(this, "Alarms", {
       alarmNamePrefix: `${stage}-cloudfront`,


### PR DESCRIPTION
# Pull Request

## Description

Reuse MonitoringSubscription ID from previous deployment

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined
