### PR TITLE
FLEX-341 fix: Point to correct bucket prefix and parse oasdiff output

### DIFF
--- a/platform/infra/flex/checkov.yaml
+++ b/platform/infra/flex/checkov.yaml
@@ -5,4 +5,3 @@ skip-check:
   - CKV_AWS_117
   - CKV_AWS_158
   - CKV_AWS_173 # TODO: confirm if we need to encrypt lambda environment variables
-  - CKV_AWS_68 # TODO: awaiting WAF

--- a/scripts/checkOpenapiBreaking.ts
+++ b/scripts/checkOpenapiBreaking.ts
@@ -9,11 +9,10 @@ import {
 } from "@aws-sdk/client-s3";
 import { z } from "zod";
 
-const SPEC_PREFIX = "docs/specs";
 const SPECS_CURRENT_DIR = "dist/openapi/current";
 const SPECS_LATEST_DIR = "dist/openapi/latest";
 const OVERRIDE_LABEL = "breaking-change-accepted";
-const BUCKET_NAME = `flex-development-openapi-specs`;
+const BUCKET_NAME = "flex-development-openapi-specs";
 
 const EnvSchema = z.object({
   OVERRIDE: z
@@ -52,7 +51,7 @@ async function downloadLatestSpecFiles() {
     const listed = await s3.send(
       new ListObjectsV2Command({
         Bucket: BUCKET_NAME,
-        Prefix: SPEC_PREFIX,
+        Prefix: "docs",
       }),
     );
 
@@ -100,7 +99,7 @@ function runOasdiff(latest: string, current: string) {
   if (res.status !== 0 && !out) {
     throw new Error(`oasdiff failed on ${current}: ${res.stderr}`);
   }
-  return out ? OasDiffBreakingSchema.parse(out) : [];
+  return out ? OasDiffBreakingSchema.parse(JSON.parse(out)) : [];
 }
 
 async function main(): Promise<number> {


### PR DESCRIPTION
# Pull Request

## Description

Point to correct bucket prefix and parse oasdiff output

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-341 

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
