### PR TITLE
GOVUKAPP-3701 chore: remove dvla unlinking for now due to deleting test IDs

### DIFF
--- a/domains/udp/src/handlers/v1/identity/[service]/delete.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.ts
@@ -6,7 +6,7 @@ import createHttpError from "http-errors";
 import status from "http-status";
 
 export const handler = route("DELETE /v1/identity/:service", async (ctx) => {
-  const { auth, pathParams, integrations } = ctx;
+  const { auth, pathParams } = ctx;
   const service = pathParams.service.toLowerCase();
 
   // TODO: SDK auth alias
@@ -17,14 +17,14 @@ export const handler = route("DELETE /v1/identity/:service", async (ctx) => {
 
   /**
    * NOTE:
-   * For now ignoring the response from DVLA as they are just returning 404
+   * - Commenting out for now as causing issues due to deleting the linking id
    */
-  if (service === "dvla") {
-    await integrations.dvlaUnlinkUser({
-      body: {},
-      path: `/${identity.serviceId}`,
-    });
-  }
+  // if (service === "dvla") {
+  //   await integrations.dvlaUnlinkUser({
+  //     body: {},
+  //     path: `/${identity.serviceId}`,
+  //   });
+  // }
 
   await deleteOrchestrateIdentityUnlink({
     ctx,

--- a/domains/udp/src/handlers/v1/identity/[service]/delete.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.ts
@@ -18,6 +18,7 @@ export const handler = route("DELETE /v1/identity/:service", async (ctx) => {
   /**
    * NOTE:
    * - Commenting out for now as causing issues due to deleting the linking id
+   *   on DVLA side
    */
   // if (service === "dvla") {
   //   await integrations.dvlaUnlinkUser({


### PR DESCRIPTION
# Pull Request

## Description

Removing the call out to DVLA for now due to it deleting the linking IDs we use for testing

**Related Issue:** https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/617

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
