### PR TITLE
FLEX-273 fix(smoke-test): drop vitest from Lambda bundle, suppress default alarms

### DIFF
--- a/libs/testing/package.json
+++ b/libs/testing/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "exports": {
     ".": "./src/index.ts",
+    "./auth": "./src/index.auth.ts",
     "./e2e": "./src/index.e2e.ts",
     "./e2e/setup": "./src/e2e/setup.global.ts",
     "./setup/sdk": "./src/setup/sdk.ts"

--- a/libs/testing/src/index.auth.ts
+++ b/libs/testing/src/index.auth.ts
@@ -1,0 +1,11 @@
+export {
+  getStubTokenGenerator,
+  getStubTokenGeneratorFromJWK,
+  STUB_DEFAULT_SUBJECT,
+} from "./fixtures/StubTokenGenerator";
+export {
+  type BaseTokenGenerator,
+  getAccessToken,
+  getTokenGenerator,
+  type OneLoginAuthConfig,
+} from "./fixtures/TokenGenerator";

--- a/platform/infra/flex/src/constructs/lambda/flex-private-egress-function.ts
+++ b/platform/infra/flex/src/constructs/lambda/flex-private-egress-function.ts
@@ -15,6 +15,7 @@ const { stage } = getEnvConfig();
 interface FlexPrivateEgressFunctionProps extends FlexFunctionProps {
   vpc: IVpc;
   privateEgressSg: ISecurityGroup;
+  disableDefaultAlarms?: boolean;
 }
 
 export class FlexPrivateEgressFunction extends Construct {
@@ -28,6 +29,7 @@ export class FlexPrivateEgressFunction extends Construct {
       privateEgressSg,
       criticalAction,
       warningAction,
+      disableDefaultAlarms,
       ...functionProps
     }: FlexPrivateEgressFunctionProps,
   ) {
@@ -54,12 +56,14 @@ export class FlexPrivateEgressFunction extends Construct {
       },
     });
 
-    new LambdaAlarms(this, "Alarm", {
-      fn: this.function,
-      alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,
-      criticalAction,
-      warningAction,
-    });
+    if (!disableDefaultAlarms) {
+      new LambdaAlarms(this, "Alarm", {
+        fn: this.function,
+        alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,
+        criticalAction,
+        warningAction,
+      });
+    }
 
     if (functionProps.domain) {
       Tags.of(this.function).add("ResourceOwner", functionProps.domain, {

--- a/platform/infra/flex/src/stacks/smoke-test.ts
+++ b/platform/infra/flex/src/stacks/smoke-test.ts
@@ -119,6 +119,8 @@ export class FlexSmokeTestStack extends BaseStack {
       privateEgressSg,
       criticalAction,
       warningAction,
+      // The explicit SmokeTestAlarm below already covers this lambda's health
+      disableDefaultAlarms: true,
     });
 
     applyCheckovSkips(smokeTest.function, [

--- a/platform/smoke-test/src/credentials.ts
+++ b/platform/smoke-test/src/credentials.ts
@@ -1,8 +1,8 @@
-import { getStubTokenGenerator } from "@flex/testing/e2e";
+import { getStubTokenGenerator } from "@flex/testing/auth";
 import {
   getAccessToken,
   type OneLoginAuthConfig as AuthConfig,
-} from "@flex/testing/e2e";
+} from "@flex/testing/auth";
 
 import { loadApiUrl, loadConfig, loadGcpConfig } from "./config";
 import { getAttestationToken } from "./gcp";


### PR DESCRIPTION
# Pull Request

## Description

The smoke-test Lambda was throwing `Vitest failed to find the current suite` in production. Root cause: `credentials.ts` imported from `@flex/testing/e2e`, which transitively imports vitest's `it` (a module-level side effect) — esbuild bundled it into the deployed Lambda artifact, which then executes outside any test runner. Fixed by switching to the new vitest-free `@flex/testing/auth` subpath, which exposes the same `getStubTokenGenerator`/`getAccessToken` fixtures without pulling in vitest. Verified by bundling `handler.ts` with esbuild directly and confirming no `vitest` import/require survives in the output.

Also excluded the smoke-test Lambda from the default per-function `LambdaAlarms` (error rate, throttles, duration), since the existing `SmokeTestAlarm` (based on the `SmokeTestSuccess` custom metric) is the intended signal for this function and the generic alarms were redundant noise.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-273

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

Bundled `platform/smoke-test/src/handler.ts` with esbuild (mirroring the CDK `NodejsFunction` bundle) and grepped the output for `from "vitest"` / `require("vitest")` — no matches. Ran `pnpm tsc` in `platform/infra/flex` to confirm the new `disableDefaultAlarms` prop type-checks cleanly.

## Checklist

- [ ] I have run the pre-commit
- [x] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_N/A_

## Additional Notes

The `SmokeTestAlarm` currently has no `addAlarmAction` attached, so it doesn't notify anyone yet — this is a follow-up, not included here.