### PR TITLE
FLEX-0000 fix(smoke): pass attestation token through to proxy token exchange

### DIFF
--- a/libs/testing/src/fixtures/TokenGenerator.ts
+++ b/libs/testing/src/fixtures/TokenGenerator.ts
@@ -105,7 +105,12 @@ export async function getAccessToken(
 
   const response = await fetch(`https://${config.tokenUrl}/oauth2/token`, {
     method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      ...(config.attestationToken && {
+        "x-attestation-token": config.attestationToken,
+      }),
+    },
     body: querystring.stringify({
       grant_type: "authorization_code",
       client_id: config.clientId,

--- a/platform/smoke-test/src/credentials.ts
+++ b/platform/smoke-test/src/credentials.ts
@@ -41,14 +41,15 @@ async function getProductionCredentials(): Promise<Credentials> {
     loadConfig("production"),
     loadGcpConfig("production"),
   ]);
-  const [accessToken, attestationToken] = await Promise.all([
-    getAccessToken(toAuthConfig(config)),
-    getAttestationToken(
-      gcpConfig.gcpCredentialConfig,
-      gcpConfig.gcpServiceAccountEmail,
-      gcpConfig.firebaseAppId,
-    ),
-  ]);
+  const attestationToken = await getAttestationToken(
+    gcpConfig.gcpCredentialConfig,
+    gcpConfig.gcpServiceAccountEmail,
+    gcpConfig.firebaseAppId,
+  );
+  const accessToken = await getAccessToken({
+    ...toAuthConfig(config),
+    attestationToken,
+  });
   return { accessToken, attestationToken, apiUrl: config.apiUrl };
 }
 


### PR DESCRIPTION
# Pull Request

## Description

The production smoke test was fetching the GCP attestation token in parallel
with `getAccessToken`, so the token was never available inside the token
exchange request. The auth proxy requires `x-attestation-token` on the
`/oauth2/token` call when the ATTESTATION feature flag is enabled.

Changes:
- `TokenGenerator.ts`: include `x-attestation-token` header in the proxy
  token exchange request when `config.attestationToken` is set
- `credentials.ts`: fetch the GCP attestation token before calling
  `getAccessToken` (sequential rather than parallel) so it can be forwarded
  to the proxy

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-XXXX

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual testing (include instructions below)

Verified locally that a token exchange request to the proxy succeeds when
`x-attestation-token` is included. Production smoke test previously fetched
the attestation token in parallel and never passed it to the proxy.

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Additional Notes

Staging smoke test returns 403 on the token exchange independently of this
change — the ATTESTATION feature flag is disabled in staging and no GCP
params exist there, so the header cannot be sent. The staging 403 appears to
originate from a WAF rule on the proxy's API Gateway and is a separate
infrastructure issue.
