### PR TITLE
FLEX-420 feat(ci): add explicit least-privilege permissions to all GHA workflows

### DIFF
--- a/.github/workflows/_build-deploy.yml
+++ b/.github/workflows/_build-deploy.yml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       id-token: write # Required for OIDC authentication with AWS
+      contents: read
     env:
       STAGE: ${{ inputs.STAGE }}
     environment: ${{ inputs.STAGE }}

--- a/.github/workflows/_moduleE2E.yml
+++ b/.github/workflows/_moduleE2E.yml
@@ -19,6 +19,8 @@ jobs:
   discover:
     name: Discover module E2E suites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       modules: ${{ steps.list.outputs.modules }}
     steps:
@@ -43,6 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_quality-checks.yml
+++ b/.github/workflows/_quality-checks.yml
@@ -26,6 +26,8 @@ jobs:
     name: Hygiene
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repo
@@ -88,6 +90,8 @@ jobs:
     name: SonarQube
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/ci-pr-quality-checks.yml
+++ b/.github/workflows/ci-pr-quality-checks.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: false
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   quality-checks:
     name: Quality Checks

--- a/.github/workflows/ci-pr-validate-openapi.yml
+++ b/.github/workflows/ci-pr-validate-openapi.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   validate-openapi:
     name: Validate Open API Spec

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
   qualityChecks:
     name: Quality Checks
     uses: ./.github/workflows/_quality-checks.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "development"
@@ -121,6 +124,9 @@ jobs:
     name: Deploy to Development
     needs: [qualityChecks, release]
     uses: ./.github/workflows/_build-deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "development"
@@ -131,6 +137,9 @@ jobs:
     name: Module E2E (Development)
     needs: deployDev
     uses: ./.github/workflows/_moduleE2E.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "development"
@@ -141,6 +150,9 @@ jobs:
     name: Deploy to Staging
     needs: deployDev
     uses: ./.github/workflows/_build-deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "staging"
@@ -151,6 +163,9 @@ jobs:
     name: Notify Staging Deployment
     needs: [release, deployStaging]
     uses: ./.github/workflows/_notify-deployment.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       ENVIRONMENT: staging
       VERSION: ${{ needs.release.outputs.version }}
@@ -161,6 +176,9 @@ jobs:
     name: Module E2E (Staging)
     needs: deployStaging
     uses: ./.github/workflows/_moduleE2E.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "staging"
@@ -171,6 +189,9 @@ jobs:
     name: Deploy to Production
     needs: deployStaging
     uses: ./.github/workflows/_build-deploy.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "production"
@@ -181,6 +202,9 @@ jobs:
     name: Notify Production Deployment
     needs: [release, deployProd]
     uses: ./.github/workflows/_notify-deployment.yml
+    permissions:
+      id-token: write
+      contents: read
     with:
       ENVIRONMENT: production
       VERSION: ${{ needs.release.outputs.version }}

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -17,13 +17,12 @@ on:
         type: string
         default: eu-west-2
 
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   performance:
     name: Performance Tests (${{ inputs.STAGE }})
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
     environment: ${{ inputs.STAGE }}
     env:
@@ -86,6 +85,8 @@ jobs:
 
   generate-report:
     needs: performance
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo

--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -7,11 +7,6 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  id-token: write # Required for AWS OIDC
-  contents: read
-  security-events: write # Required for SARIF upload
-
 jobs:
   zap_scan:
     if: |
@@ -19,6 +14,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     name: ⚡️ Zap staging
+    permissions:
+      id-token: write # Required for AWS OIDC
+      contents: read
+      security-events: write # Required for SARIF upload
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -75,5 +74,6 @@ jobs:
   workflow_fail:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - run: echo "❌ Continuous Deployment workflow failed"


### PR DESCRIPTION

## Pull Request

### Description

Applies explicit `permissions:` blocks to every GitHub Actions workflow and job. Without an explicit block, workflows inherit the organisation or repository default permissions, which may be broader than needed.

Permissions are declared at the **job level** wherever possible. Workflow-level blocks are used only where a single inline job makes them equivalent, or where a caller workflow must set a ceiling for reusable workflow jobs that do not declare their own permissions.

**Note on reusable workflows and ceilings:** GitHub passes the caller workflow's `permissions` block as the ceiling for all jobs in a called reusable workflow. Where a reusable workflow's jobs already declare their own job-level permissions (e.g. `_quality-checks.yml`, `_build-deploy.yml`, `_moduleE2E.yml`), those declarations take effect directly and the caller's ceiling does not widen them. The ceiling still matters as a safety net and for any job that omits its own declaration.

**Note on `contents: write`:** This permission is scoped exclusively to the `release` job in `main.yml`, which requires it for semantic-release tag and release creation. No other job or workflow holds `contents: write`.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-420

### Type of Change

- [x] Other (IT health check remediation — least-privilege CI/CD permissions)

### How Has This Been Tested?

- [x] Manual testing 

### Checklist

- [x] I have run the pre-commit
- [x] I have performed a self-review of my code
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation

### Additional Notes

`contents: write` is now held by exactly one job (`release` in `main.yml`). Every other job is capped at `contents: read` or lower, and AWS OIDC (`id-token: write`) is granted only to jobs that authenticate with AWS.
