### PR TITLE
FLEX-0000 fix(smoke-test): run smoke-test lambda outside VPC

### DIFF
--- a/platform/infra/flex/src/constructs/lambda/flex-private-egress-function.ts
+++ b/platform/infra/flex/src/constructs/lambda/flex-private-egress-function.ts
@@ -15,7 +15,7 @@ const { stage } = getEnvConfig();
 interface FlexPrivateEgressFunctionProps extends FlexFunctionProps {
   vpc: IVpc;
   privateEgressSg: ISecurityGroup;
-  disableDefaultAlarms?: boolean;
+  enableDefaultAlarms?: boolean;
 }
 
 export class FlexPrivateEgressFunction extends Construct {
@@ -29,7 +29,7 @@ export class FlexPrivateEgressFunction extends Construct {
       privateEgressSg,
       criticalAction,
       warningAction,
-      disableDefaultAlarms,
+      enableDefaultAlarms = true,
       ...functionProps
     }: FlexPrivateEgressFunctionProps,
   ) {
@@ -60,7 +60,7 @@ export class FlexPrivateEgressFunction extends Construct {
 
     encryptionKey.grantDecrypt(this.function);
 
-    if (!disableDefaultAlarms) {
+    if (enableDefaultAlarms) {
       new LambdaAlarms(this, "Alarm", {
         fn: this.function,
         alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,

--- a/platform/infra/flex/src/constructs/lambda/flex-public-function.ts
+++ b/platform/infra/flex/src/constructs/lambda/flex-public-function.ts
@@ -12,7 +12,7 @@ import { FlexFunctionProps } from "../types";
 const { stage } = getEnvConfig();
 
 interface FlexPublicFunctionProps extends FlexFunctionProps {
-  disableDefaultAlarms?: boolean;
+  enableDefaultAlarms?: boolean;
 }
 
 export class FlexPublicFunction extends Construct {
@@ -24,7 +24,7 @@ export class FlexPublicFunction extends Construct {
     {
       criticalAction,
       warningAction,
-      disableDefaultAlarms,
+      enableDefaultAlarms = true,
       ...functionProps
     }: FlexPublicFunctionProps,
   ) {
@@ -50,7 +50,7 @@ export class FlexPublicFunction extends Construct {
 
     encryptionKey.grantDecrypt(this.function);
 
-    if (!disableDefaultAlarms) {
+    if (enableDefaultAlarms) {
       new LambdaAlarms(this, `${id}Alarm`, {
         fn: this.function,
         alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,

--- a/platform/infra/flex/src/constructs/lambda/flex-public-function.ts
+++ b/platform/infra/flex/src/constructs/lambda/flex-public-function.ts
@@ -11,13 +11,22 @@ import { FlexFunctionProps } from "../types";
 
 const { stage } = getEnvConfig();
 
+interface FlexPublicFunctionProps extends FlexFunctionProps {
+  disableDefaultAlarms?: boolean;
+}
+
 export class FlexPublicFunction extends Construct {
   public readonly function: NodejsFunction;
 
   constructor(
     scope: Construct,
     id: string,
-    { criticalAction, warningAction, ...functionProps }: FlexFunctionProps,
+    {
+      criticalAction,
+      warningAction,
+      disableDefaultAlarms,
+      ...functionProps
+    }: FlexPublicFunctionProps,
   ) {
     super(scope, id);
 
@@ -41,12 +50,14 @@ export class FlexPublicFunction extends Construct {
 
     encryptionKey.grantDecrypt(this.function);
 
-    new LambdaAlarms(this, `${id}Alarm`, {
-      fn: this.function,
-      alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,
-      criticalAction,
-      warningAction,
-    });
+    if (!disableDefaultAlarms) {
+      new LambdaAlarms(this, `${id}Alarm`, {
+        fn: this.function,
+        alarmNamePrefix: `${stage}-${id.toLowerCase()}-alarm`,
+        criticalAction,
+        warningAction,
+      });
+    }
 
     if (functionProps.domain) {
       Tags.of(this.function).add("ResourceOwner", functionProps.domain, {

--- a/platform/infra/flex/src/stacks/smoke-test.ts
+++ b/platform/infra/flex/src/stacks/smoke-test.ts
@@ -19,9 +19,8 @@ import type { Construct } from "constructs";
 
 import { BaseStack } from "../base";
 import { importAlarmActions } from "../constructs/alarms/actions";
-import { FlexPrivateEgressFunction } from "../constructs/lambda/flex-private-egress-function";
+import { FlexPublicFunction } from "../constructs/lambda/flex-public-function";
 import { ENV_KEYS, PLATFORM_KEYS } from "../ssm-keys";
-import { applyCheckovSkips } from "../utils/applyCheckovSkip";
 import { getPlatformSmokeTestEntry } from "../utils/getEntry";
 
 const { env, stage } = getEnvConfig();
@@ -49,7 +48,7 @@ export class FlexSmokeTestStack extends BaseStack {
       assumedBy: new ServicePrincipal("lambda.amazonaws.com"),
       managedPolicies: [
         ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AWSLambdaVPCAccessExecutionRole",
+          "service-role/AWSLambdaBasicExecutionRole",
         ),
       ],
     });
@@ -108,28 +107,14 @@ export class FlexSmokeTestStack extends BaseStack {
       );
     }
 
-    const vpc = this.importVpc(ENV_KEYS.Vpc);
-    const privateEgressSg = this.importSecurityGroup(ENV_KEYS.SgPrivateEgress);
-
-    const smokeTest = new FlexPrivateEgressFunction(this, "SmokeTestFunction", {
+    const smokeTest = new FlexPublicFunction(this, "SmokeTestFunction", {
       entry: getPlatformSmokeTestEntry("handler.ts"),
       timeout: Duration.minutes(2),
       role,
-      vpc,
-      privateEgressSg,
       criticalAction,
       warningAction,
-      // The explicit SmokeTestAlarm below already covers this lambda's health
       disableDefaultAlarms: true,
     });
-
-    applyCheckovSkips(smokeTest.function, [
-      {
-        id: "CKV_AWS_117",
-        comment:
-          "Smoke test Lambda intentionally in VPC for egress to external auth services",
-      },
-    ]);
 
     const rule = new Rule(this, "SmokeTestSchedule", {
       schedule: Schedule.rate(Duration.minutes(5)),

--- a/platform/infra/flex/src/stacks/smoke-test.ts
+++ b/platform/infra/flex/src/stacks/smoke-test.ts
@@ -113,7 +113,8 @@ export class FlexSmokeTestStack extends BaseStack {
       role,
       criticalAction,
       warningAction,
-      disableDefaultAlarms: true,
+      // smoke test function already covers lambda health, so we don't need to create additional alarms for it
+      enableDefaultAlarms: false,
     });
 
     const rule = new Rule(this, "SmokeTestSchedule", {


### PR DESCRIPTION
# Pull Request

## Description

The smoke test has been failing in both staging and production with
`getAccessToken { message: Forbidden }` during the OAuth token exchange,
independently of the attestation-token-forwarding and domain fixes merged
yesterday (#388, #395).

Root cause: Flex's VPC has an Interface VPC Endpoint for API Gateway
(`core/endpoints.ts`) with `privateDnsEnabled: true`. This creates a private
hosted zone covering the entire `execute-api.eu-west-2.amazonaws.com`
namespace inside Flex's VPC — not scoped to Flex's own APIs. Any Lambda
running in that VPC, including the smoke test (previously in
`PRIVATE_WITH_EGRESS` subnets via `FlexPrivateEgressFunction`), resolved
`auth`'s hostname to Flex's own VPC endpoint
ENI instead of the real public endpoint. Since that endpoint has no
authorization for a third-party account's API, it returned AWS's generic
default response, `{"message":"Forbidden"}` at 403 — with zero trace in
`govuk-mobile-backend`'s own API Gateway access logs or WAF logs, because the
request never left Flex's account.

Confirmed via:
- No matching entries in `auth`'s logs for the failing request's timestamp

This affects only the `ApiGateway` VPC endpoint (not SSM/Secrets
Manager/KMS/CloudWatch Logs, which don't hijack `execute-api.*`), and
affects staging and production identically since both environments carry
the same VPC/endpoint construct.

Changes:
- `smoke-test.ts`: switch the smoke-test Lambda from
  `FlexPrivateEgressFunction` (VPC, `PRIVATE_WITH_EGRESS`) to
  `FlexPublicFunction` (no VPC), so it resolves `execute-api.*` hostnames
  publicly — the same path a real mobile client uses. Removed the
  now-redundant `CKV_AWS_117` per-resource skip (already covered by a
  repo-wide skip in `checkov.yaml`).
- `flex-public-function.ts`: added an optional `disableDefaultAlarms` prop
  (mirroring `FlexPrivateEgressFunction`) to preserve the existing
  `SmokeTestAlarm`-only alerting behaviour.
- `smoke-test.ts`: swapped the Lambda's IAM managed policy from
  `AWSLambdaVPCAccessExecutionRole` to `AWSLambdaBasicExecutionRole` now
  that it's no longer VPC-attached — same CloudWatch Logs permissions,
  drops the now-unused EC2 network-interface permissions
  (`CreateNetworkInterface`/`DeleteNetworkInterface`/etc.) for least
  privilege.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-XXXX

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Not applicable — infrastructure/networking change._

## Additional Notes

_Anything else you want to mention for reviewers?_
