### PR TITLE
FLEX-0000 fix(ci): correct permissions for test coverage

### DIFF
--- a/.github/workflows/_quality-checks.yml
+++ b/.github/workflows/_quality-checks.yml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      actions: read # required by nrwl/nx-set-shas to find the last successful workflow run on main
 
     steps:
       - name: Checkout repo
@@ -92,6 +93,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      actions: read # required by nrwl/nx-set-shas to find the last successful workflow run on main
 
     steps:
       - name: Checkout repo
@@ -154,6 +156,7 @@ jobs:
     permissions:
       id-token: write # OIDC for AWS
       contents: read
+      actions: read # required by nrwl/nx-set-shas to find the last successful workflow run on main
     env:
       STAGE: ${{ inputs.STAGE }}
 

--- a/.github/workflows/ci-pr-quality-checks.yml
+++ b/.github/workflows/ci-pr-quality-checks.yml
@@ -12,6 +12,7 @@ concurrency:
 permissions:
   id-token: write
   contents: read
+  actions: read # ceiling for _quality-checks.yml jobs using nrwl/nx-set-shas
 
 jobs:
   quality-checks:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      actions: read # required by nrwl/nx-set-shas to find the last successful workflow run on main
     with:
       AWS_REGION: "eu-west-2"
       STAGE: "development"


### PR DESCRIPTION
## Pull Request

### Description

After #396 (least-privilege GHA permissions) merged, SonarQube scans on `main` started reporting 0% coverage and flagging all code as new/uncovered, even though the same code passed quality checks on its PR branch.

**Root cause:** the `hygiene`, `sonarScan`, and `security` jobs in `_quality-checks.yml` all run `nrwl/nx-set-shas` before `nx affected`, to determine which SHA to diff against. On `push` events (i.e. `main`), `nx-set-shas` calls the GitHub Actions API to find the SHA of the last successful workflow run — this requires `actions: read`. Declaring an explicit `permissions:` block (as #396 did) sets every unlisted scope to `none`, so `actions: read` — previously available via the default token permissions — was silently revoked.

With no successful-run SHA to diff against, `nx affected --target=test --coverage` resolved no affected projects, so no tests ran and the coverage report submitted to Sonar was empty. Sonar then treated all of `main`'s code as new and 0%-covered, failing the quality gate.

This only affected `main`, not PR branches, because `nx-set-shas` resolves the base SHA differently for `pull_request` events — it reads `base.sha` directly from the event payload and doesn't need the Actions API. That's why PR runs passed cleanly while `main` broke.

Also note: for reusable workflow calls, the caller's `permissions:` block is a hard ceiling — a called job's own `permissions:` cannot exceed it. So `actions: read` had to be added both to the jobs in `_quality-checks.yml` and to the ceilings in the workflows that call it (`main.yml`, `ci-pr-quality-checks.yml`).

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-XXXX

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- [x] Manual testing (include instructions below)

1. Merge this PR to `main` and confirm the `Continuous Deployment` workflow's `Quality Checks` job runs.
2. In the `NX - set SHAs` step logs (for `hygiene`, `sonarScan`, `security`), confirm there is no "no successful workflow run found" warning and a real base SHA is resolved.
3. Confirm `nx affected --target=test --coverage` picks up the actually-affected projects (not zero).
4. Confirm the SonarQube scan reports non-zero coverage and does not flag unrelated/pre-existing code as new.
5. Re-run the `Release Candidate` workflow on an open PR and confirm it still passes (this path was already unaffected, should remain green).

### Checklist

- [x] I have run the pre-commit
- [x] I have performed a self-review of my code
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation

### Additional Notes

This is a follow-up correction to #396. `nrwl/nx-set-shas` documents `actions: read` (alongside `contents: read`, and `pull-requests: read` for merge queues) as a required permission — this was missed in the original least-privilege pass since the failure mode only surfaces on `push` to `main`, not on `pull_request` runs.
