### PR TITLE
FLEX-0000 fix(ci): restore full coverage for sonar scan

### DIFF
--- a/.github/workflows/_quality-checks.yml
+++ b/.github/workflows/_quality-checks.yml
@@ -93,7 +93,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      actions: read # required by nrwl/nx-set-shas to find the last successful workflow run on main
 
     steps:
       - name: Checkout repo
@@ -113,9 +112,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: NX - set SHAs
-        uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
-
       - name: Cache NX
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -131,7 +127,7 @@ jobs:
           AWS_DEFAULT_REGION: eu-west-2
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test # pragma: allowlist secret
-        run: pnpm exec nx affected --target=test --run --coverage --skip-nx-cache
+        run: pnpm exec nx run-many --target=test --all --run --coverage --skip-nx-cache
 
       - name: Generate report for SonarQube
         run: pnpm run lint:report || true


### PR DESCRIPTION
# Pull Request

## Description

sonarScan's Unit Tests step was using nx affected, which only produces coverage for packages changed since the last successful workflow run on main. Since sonar-project.properties scans the entire domains, libs, platform tree on every run, any push touching fewer than all 22 projects left Sonar with a full-source scan but partial coverage data, understating coverage and risking quality gate failures.

PR #232 originally fixed this by always using nx run-many --all, specifically to avoid this coverage cliff between PR and main. PR #326 (FLEX-356, CI parallelisation) silently reverted that back to nx affected while restructuring the quality-checks job. PR #396 (least-privilege permissions) then broke nx-set-shas's base SHA lookup entirely, turning the latent regression into guaranteed 0% coverage on every main push. PR #398 fixed the SHA lookup but left the #326 regression in place, so main was still only getting partial coverage on any push that didn't touch every project.

This restores the #232 behaviour: sonarScan always runs the full test suite with coverage, regardless of what changed. It also drops the now-unused NX - set SHAs step and actions: read permission from the sonarScan job, since nx run-many needs no base/head diff to compute. hygiene and security keep both, since lint, tsc, and checkov still call nx affected internally.

Related Issue: https://gdsgovukagents.atlassian.net/browse/FLEX-XXXX

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

How Has ### This Been Tested?

- [x] Manual testing (include instructions below)

1. Push to main and confirm the sonarScan job's Unit Tests step runs nx run-many --target=test --all --coverage and executes all 22 projects, not a subset.
2. Confirm coverage/lcov.info is generated for every project, not just ones touched by the latest commit.
3. Confirm the SonarQube scan reports coverage consistent with the full codebase and the quality gate reflects real coverage, not 0%/partial.
4. Confirm hygiene and security jobs still resolve NX_BASE/NX_HEAD correctly via nx-set-shas (lint, tsc, checkov are unaffected by this change).

### Checklist

- [x] I have run the pre-commit
- [x] I have performed a self-review of my code
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
