### PR TITLE
FLEX-426 feat(vpc): vpc flow logs

### DIFF
--- a/platform/infra/flex/src/constructs/s3/FlowLogBucket.ts
+++ b/platform/infra/flex/src/constructs/s3/FlowLogBucket.ts
@@ -1,0 +1,51 @@
+import { Duration } from "aws-cdk-lib";
+import { IKey } from "aws-cdk-lib/aws-kms";
+import {
+  BlockPublicAccess,
+  Bucket,
+  BucketAccessControl,
+  BucketEncryption,
+  ObjectLockMode,
+  ObjectOwnership,
+} from "aws-cdk-lib/aws-s3";
+import { Construct } from "constructs";
+
+import { applyCheckovSkip } from "../../utils/applyCheckovSkip";
+
+export class FlowLogBucket extends Construct {
+  public readonly bucket: Bucket;
+
+  constructor(scope: Construct, id: string, encryptionKey: IKey) {
+    super(scope, id);
+
+    this.bucket = new Bucket(this, "FlowLogBucket", {
+      enforceSSL: true,
+      publicReadAccess: false,
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      objectOwnership: ObjectOwnership.OBJECT_WRITER,
+      accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
+      encryption: BucketEncryption.KMS,
+      encryptionKey,
+      bucketKeyEnabled: true,
+      versioned: true,
+      objectLockEnabled: true,
+      objectLockDefaultRetention: {
+        mode: ObjectLockMode.GOVERNANCE,
+        duration: Duration.days(365),
+      },
+      lifecycleRules: [
+        {
+          id: "deleteLogsAfter12Months",
+          expiration: Duration.days(365),
+          noncurrentVersionExpiration: Duration.days(365),
+        },
+      ],
+    });
+
+    applyCheckovSkip(
+      this.bucket,
+      "CKV_AWS_18",
+      "Log bucket intentionally does not log",
+    );
+  }
+}

--- a/platform/infra/flex/src/stacks/core/vpc.ts
+++ b/platform/infra/flex/src/stacks/core/vpc.ts
@@ -1,15 +1,26 @@
+import { Stack } from "aws-cdk-lib";
 import {
   AclCidr,
   AclTraffic,
   Action,
+  FlowLogDestination,
+  FlowLogFileFormat,
+  FlowLogMaxAggregationInterval,
+  FlowLogTrafficType,
   IpAddresses,
+  IVpc,
+  LogFormat,
   NetworkAcl,
   SecurityGroup,
   SubnetType,
   TrafficDirection,
   Vpc,
 } from "aws-cdk-lib/aws-ec2";
+import { Effect, PolicyStatement, ServicePrincipal } from "aws-cdk-lib/aws-iam";
+import { Key } from "aws-cdk-lib/aws-kms";
 import { Construct } from "constructs";
+
+import { FlowLogBucket } from "../../constructs/s3/FlowLogBucket";
 
 function addInboundDenies90to100(prefix: string, nacl: NetworkAcl) {
   nacl.addEntry(`${prefix}DenyInboundSystemPortsTcp`, {
@@ -123,6 +134,57 @@ function applyPrivateIsolatedRules(scope: Construct, vpc: Vpc) {
   addInboundDenies90to100(prefix, privateIsolatedNacl);
 }
 
+// Enables VPC-wide flow logs to a dedicated, KMS-encrypted S3 bucket.
+function createFlowLogs(scope: Construct, vpc: IVpc) {
+  const stack = Stack.of(scope);
+
+  const flowLogKey = new Key(scope, "FlowLogKey", {
+    alias: "alias/flex-vpc-flow-logs-key",
+    description: "KMS key for VPC flow log encryption",
+    enableKeyRotation: true,
+  });
+
+  // Only grants the write path used by log delivery. Read access
+  // (kms:Decrypt) is intentionally not granted to any role here - grant it to
+  // a specific role in a follow-up once a reader (e.g. an investigator role
+  // or Athena) is needed.
+  flowLogKey.addToResourcePolicy(
+    new PolicyStatement({
+      sid: "AllowVpcFlowLogDelivery",
+      effect: Effect.ALLOW,
+      principals: [new ServicePrincipal("delivery.logs.amazonaws.com")],
+      actions: ["kms:Encrypt", "kms:GenerateDataKey*", "kms:DescribeKey"],
+      resources: ["*"],
+      conditions: {
+        StringEquals: { "aws:SourceAccount": stack.account },
+        ArnLike: {
+          "aws:SourceArn": stack.formatArn({ service: "logs", resource: "*" }),
+        },
+      },
+    }),
+  );
+
+  const { bucket } = new FlowLogBucket(scope, "FlowLogBucket", flowLogKey);
+
+  vpc.addFlowLog("FlowLog", {
+    destination: FlowLogDestination.toS3(bucket, undefined, {
+      fileFormat: FlowLogFileFormat.PLAIN_TEXT,
+    }),
+    trafficType: FlowLogTrafficType.ALL,
+    maxAggregationInterval: FlowLogMaxAggregationInterval.ONE_MINUTE,
+    logFormat: [
+      LogFormat.ALL_DEFAULT_FIELDS,
+      LogFormat.VPC_ID,
+      LogFormat.SUBNET_ID,
+      LogFormat.INSTANCE_ID,
+      LogFormat.TCP_FLAGS,
+      LogFormat.PKT_SRC_ADDR,
+      LogFormat.PKT_DST_ADDR,
+      LogFormat.FLOW_DIRECTION,
+    ],
+  });
+}
+
 export function createVpc(scope: Construct) {
   const vpc = new Vpc(scope, "Vpc", {
     ipAddresses: IpAddresses.cidr("10.0.0.0/16"),
@@ -150,6 +212,7 @@ export function createVpc(scope: Construct) {
   applyPublicRules(scope, vpc);
   applyPrivateEgressRules(scope, vpc);
   applyPrivateIsolatedRules(scope, vpc);
+  createFlowLogs(scope, vpc);
 
   const privateEgress = new SecurityGroup(scope, "PrivateEgress", {
     vpc,

--- a/platform/infra/flex/src/stacks/core/vpc.ts
+++ b/platform/infra/flex/src/stacks/core/vpc.ts
@@ -154,7 +154,7 @@ function createFlowLogs(scope: Construct, vpc: IVpc) {
       effect: Effect.ALLOW,
       principals: [new ServicePrincipal("delivery.logs.amazonaws.com")],
       actions: ["kms:Encrypt", "kms:GenerateDataKey*", "kms:DescribeKey"],
-      resources: ["*"],
+      resources: [flowLogKey.keyArn],
       conditions: {
         StringEquals: { "aws:SourceAccount": stack.account },
         ArnLike: {


### PR DESCRIPTION
# Pull Request

## Description

Enables VPC-wide flow logs (ALL traffic, 1-minute aggregation, extended
field set) delivered to a dedicated, KMS-encrypted S3 bucket. Chosen over
CloudWatch Logs for cost at this volume and to keep the eventual Splunk
migration path clean (S3-native ingestion, plain-text rather than Parquet).

Flow log creation is wired into the persistent `FlexCoreStack` (via
`createVpc()` in `stacks/core/vpc.ts`), and the bucket has S3 Object Lock
enabled (GOVERNANCE mode, 365-day retention) so logs can't be casually
deleted or overwritten. The KMS key policy grants only the write path used
by log delivery (`kms:Encrypt`/`GenerateDataKey`/`DescribeKey`) -
`kms:Decrypt` is intentionally withheld until a specific reader role (e.g.
an investigator role or Athena) is needed; that's a deliberate follow-up,
not an oversight.

An earlier iteration also included a Glue table with partition projection
for ad hoc Athena queries over the logs; that was cut to reduce scope and
can be reintroduced later if/when read access is granted.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-426

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

Deployed against an ephemeral stack (flow logs temporarily wired into
`FlexPlatformStack` for this purpose) to confirm:
- Flow log records are delivered to the S3 bucket in the expected format
  and field order.
- The bucket and KMS key policies allow log delivery to succeed
  (`delivery.logs.amazonaws.com` write path).

Wiring has since been moved to the persistent `FlexCoreStack` and Object
Lock re-enabled on the bucket, matching where/how this should run
long-term.

Confirmed AWS Config missing vpc flow log conformance issue resolved.

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_N/A - infrastructure change, no UI._

## Additional Notes

`kms:Decrypt` on the flow log KMS key is intentionally not granted to any
role yet - a follow-up ticket is needed once a reader (iinvestigator role
and/or Athena) is confirmed.