### PR TITLE
FLEX-426 fix(vpc): remove KMS key self-reference causing circular dependency

### DIFF
--- a/platform/infra/flex/src/stacks/core/vpc.ts
+++ b/platform/infra/flex/src/stacks/core/vpc.ts
@@ -154,7 +154,7 @@ function createFlowLogs(scope: Construct, vpc: IVpc) {
       effect: Effect.ALLOW,
       principals: [new ServicePrincipal("delivery.logs.amazonaws.com")],
       actions: ["kms:Encrypt", "kms:GenerateDataKey*", "kms:DescribeKey"],
-      resources: [flowLogKey.keyArn],
+      resources: ["*"],
       conditions: {
         StringEquals: { "aws:SourceAccount": stack.account },
         ArnLike: {


### PR DESCRIPTION
# Pull Request

## Description

Fixes a failed deployment on the VPC flow logs feature caused by a CloudFormation circular dependency: `Circular dependency between resources: [FlowLogKeyAlias, FlowLogBucketPolicy, VpcFlowLog, FlowLogKey, FlowLogBucket]`.

The flow log KMS key's resource policy scoped its `Resource` to `flowLogKey.keyArn`, which resolves to `Fn::GetAtt: [FlowLogKey, Arn]`. `Key.addToResourcePolicy()` writes that statement directly into the same `AWS::KMS::Key` resource's own `KeyPolicy` property (KMS keys don't get a separate policy resource the way S3 buckets or SNS topics do), so this created a genuine self-reference in the CloudFormation resource graph — the key's own properties pointed back at the key's own attribute.

`cdk synth` doesn't catch this (verified: synthesizing the stack produces a clean, acyclic template), but CloudFormation's deploy-time dependency resolver does, and fails the whole stack, reporting every resource connected to the key (alias, bucket via `encryptionKey`, bucket policy, flow log) as part of the cycle.

Fix: revert `Resource` to `"*"`. This is standard practice for a resource-based policy (as opposed to an identity policy) — `"*"` here already means "this key," and the actual scoping is done by the `SourceAccount`/`SourceArn`/principal conditions already on the statement. No permissions change.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-426

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing (include instructions below)

Synthesized the `createVpc` construct in isolation both before and after the fix and inspected the generated `AWS::KMS::Key` resource:

- Before: `KeyPolicy` statement `Resource` was `{ "Fn::GetAtt": ["FlowLogKey", "Arn"] }` — a self-reference.
- After: `Resource` is `"*"`, no self-reference. The rest of the dependency chain (`FlowLogKey` → `FlowLogBucket` → `FlowLogBucketPolicy` → `VpcFlowLog`, plus `FlowLogKeyAlias` → `FlowLogKey`) is unchanged and one-directional.

Next step is redeploying to confirm CloudFormation accepts the changeset without the circular dependency error.

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_N/A — infrastructure change, no UI._

## Additional Notes

Root cause introduced in the commit that changed this statement's `Resource` from `"*"` to `flowLogKey.keyArn` ("chore: change kms key resource policy to reference itself"), as part of `FLEX-426 feat(vpc): vpc flow logs (#402)`. This PR is a one-line revert of that specific change; the rest of the flow logs feature is untouched.
