### PR TITLE
FLEX-324 fix: Update alarms to be more robust

### DIFF
--- a/platform/infra/flex/src/constructs/alarms/waf.ts
+++ b/platform/infra/flex/src/constructs/alarms/waf.ts
@@ -1,44 +1,83 @@
-import { Duration, Fn, Stack } from "aws-cdk-lib";
+import { Duration, Stack } from "aws-cdk-lib";
 import {
   Alarm,
-  CfnAlarm,
+  AnomalyDetectionAlarm,
   ComparisonOperator,
   MathExpression,
   Metric,
   Stats,
   TreatMissingData,
 } from "aws-cdk-lib/aws-cloudwatch";
-import { CfnWebACL } from "aws-cdk-lib/aws-wafv2";
 import { Construct } from "constructs";
 
 import { BaseAlarmsProps } from "./types";
 
 export interface WafAlarmsProps extends BaseAlarmsProps {
-  readonly webAcl: CfnWebACL;
+  readonly webAclScope: "CLOUDFRONT" | "REGIONAL";
+  readonly webAclMetricName: string;
+  readonly managedRuleMetricNames: string[];
 }
 
 export class WafAlarms extends Construct {
   public readonly blockingAllRequestsAlarm: Alarm;
-  public readonly blockedRequestsSpikeAlarm: CfnAlarm;
+  public readonly blockedRequestsSpikeAlarm: AnomalyDetectionAlarm;
+  public readonly managedRuleBlocksAlarm: Alarm;
 
   constructor(scope: Construct, id: string, props: WafAlarmsProps) {
     super(scope, id);
 
-    const { webAcl, criticalAction, warningAction, alarmNamePrefix } = props;
+    const {
+      criticalAction,
+      warningAction,
+      alarmNamePrefix,
+      webAclMetricName,
+      webAclScope,
+    } = props;
 
-    const dimensions = {
-      WebACL: Fn.select(2, Fn.split("/", webAcl.attrArn)),
-      Rule: "ALL",
-      Region: Stack.of(this).region,
+    const wafMetric = (metricName: string, rule: string) => {
+      return new Metric({
+        namespace: "AWS/WAFV2",
+        metricName,
+        dimensionsMap: {
+          Rule: rule,
+          WebACL: webAclMetricName,
+          // CLOUDFRONT web ACLs publish metrics without a Region dimension.
+          ...(webAclScope === "REGIONAL" && {
+            Region: Stack.of(this).region,
+          }),
+        },
+        statistic: Stats.SUM,
+        period: Duration.minutes(5),
+      });
     };
 
-    const blocked5m = new Metric({
-      namespace: "AWS/WAFV2",
-      metricName: "BlockedRequests",
-      dimensionsMap: dimensions,
-      statistic: Stats.SUM,
-      period: Duration.minutes(5),
+    const blocked = wafMetric("BlockedRequests", "ALL");
+    const allowed = wafMetric("AllowedRequests", "ALL");
+
+    const managedBlocks = Object.fromEntries(
+      props.managedRuleMetricNames.map((name, i) => [
+        `m${String(i)}`,
+        wafMetric("BlockedRequests", name),
+      ]),
+    );
+
+    this.managedRuleBlocksAlarm = new Alarm(this, "ManagedRuleBlocks", {
+      alarmName: `${alarmNamePrefix}-managed-rules-blocked-requests`,
+      alarmDescription:
+        "Critical: AWS managed rules blocking requests (known-bad inputs)",
+      metric: new MathExpression({
+        expression: Object.keys(managedBlocks)
+          .map((id) => `FILL(${id}, 0)`)
+          .join(" + "),
+        usingMetrics: managedBlocks,
+        label: "Managed rule blocks",
+      }),
+      threshold: 0,
+      evaluationPeriods: 1,
+      comparisonOperator: ComparisonOperator.GREATER_THAN_THRESHOLD,
+      treatMissingData: TreatMissingData.NOT_BREACHING,
     });
+    this.managedRuleBlocksAlarm.addAlarmAction(criticalAction);
 
     this.blockingAllRequestsAlarm = new Alarm(
       this,
@@ -50,17 +89,7 @@ export class WafAlarms extends Construct {
         metric: new MathExpression({
           expression:
             "IF((blocked + allowed) > 0, 100 * (blocked / (blocked + allowed)), 0)",
-          usingMetrics: {
-            blocked: blocked5m,
-            allowed: new Metric({
-              namespace: "AWS/WAFV2",
-              metricName: "AllowedRequests",
-              dimensionsMap: dimensions,
-              statistic: Stats.SUM,
-              period: Duration.minutes(5),
-            }),
-          },
-          period: Duration.minutes(5),
+          usingMetrics: { blocked, allowed },
           label: "Block rate (%)",
         }),
         threshold: 90,
@@ -71,51 +100,21 @@ export class WafAlarms extends Construct {
     );
     this.blockingAllRequestsAlarm.addAlarmAction(criticalAction);
 
-    const spikeAlarmCfn = new CfnAlarm(this, "BlockedRequestsSpike", {
-      alarmName: `${alarmNamePrefix}-blocked-requests-spike-anomaly`,
-      alarmDescription:
-        "Warning: blocked requests deviate from expected baseline (anomaly detection)",
-      comparisonOperator: ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
-      evaluationPeriods: 1,
-      thresholdMetricId: "expected_band",
-      treatMissingData: "notBreaching",
-      metrics: [
-        {
-          id: "blocked_requests",
-          metricStat: {
-            metric: {
-              namespace: "AWS/WAFV2",
-              metricName: "BlockedRequests",
-              dimensions: Object.entries(dimensions).map(([name, value]) => ({
-                name,
-                value,
-              })),
-            },
-            period: 300,
-            stat: Stats.SUM,
-          },
-          returnData: true,
-        },
-        {
-          id: "expected_band",
-          // 2 = bandwidth in standard deviations
-          expression: "ANOMALY_DETECTION_BAND(blocked_requests, 2)",
-          label: "BlockedRequests (expected)",
-          returnData: true,
-        },
-      ],
-    });
-
-    const spikeAlarmRef = Alarm.fromAlarmArn(
+    this.blockedRequestsSpikeAlarm = new AnomalyDetectionAlarm(
       this,
-      "BlockedRequestsSpikeRef",
-      spikeAlarmCfn.attrArn,
+      "BlockedRequestsSpike",
+      {
+        alarmName: `${alarmNamePrefix}-blocked-requests-spike-anomaly`,
+        alarmDescription:
+          "Warning: blocked requests deviate from expected baseline",
+        metric: blocked,
+        stdDevs: 2,
+        evaluationPeriods: 3,
+        datapointsToAlarm: 2,
+        comparisonOperator: ComparisonOperator.GREATER_THAN_UPPER_THRESHOLD,
+        treatMissingData: TreatMissingData.NOT_BREACHING,
+      },
     );
-
-    spikeAlarmCfn.alarmActions = [
-      warningAction.bind(this, spikeAlarmRef).alarmActionArn,
-    ];
-
-    this.blockedRequestsSpikeAlarm = spikeAlarmCfn;
+    this.blockedRequestsSpikeAlarm.addAlarmAction(warningAction);
   }
 }

--- a/platform/infra/flex/src/stacks/global.ts
+++ b/platform/infra/flex/src/stacks/global.ts
@@ -199,12 +199,21 @@ export class FlexGlobalStack extends BaseStack {
       "Using AWS managed keys is fine in this case and lets us keep the pattern consistent with origin-verify-secret",
     );
 
+    const webAclMetricName = "CfWebAcl";
+    const metricName = {
+      AWSManagedRulesCommonRuleSet: "AWSManagedRulesCommonRuleSet",
+      AWSManagedRulesKnownBadInputsRuleSet:
+        "AWSManagedRulesKnownBadInputsRuleSet",
+      AWSManagedRulesAmazonIpReputationList:
+        "AWSManagedRulesAmazonIpReputationList",
+    };
+
     const webAcl = new CfnWebACL(this, "CfWebAcl", {
       scope: "CLOUDFRONT",
       defaultAction: { allow: {} },
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
-        metricName: "WebAcl",
+        metricName: webAclMetricName,
         sampledRequestsEnabled: true,
       },
       dataProtectionConfig: {
@@ -222,34 +231,34 @@ export class FlexGlobalStack extends BaseStack {
       },
       rules: [
         {
-          name: "AWSManagedRulesCommonRuleSet",
+          name: metricName.AWSManagedRulesCommonRuleSet,
           priority: 0,
           overrideAction: { none: {} },
           statement: {
             managedRuleGroupStatement: {
               vendorName: "AWS",
-              name: "AWSManagedRulesCommonRuleSet",
+              name: metricName.AWSManagedRulesCommonRuleSet,
             },
           },
           visibilityConfig: {
             cloudWatchMetricsEnabled: true,
-            metricName: "AWSManagedRulesCommonRuleSet",
+            metricName: metricName.AWSManagedRulesCommonRuleSet,
             sampledRequestsEnabled: true,
           },
         },
         {
-          name: "AWSManagedRulesKnownBadInputsRuleSet",
+          name: metricName.AWSManagedRulesKnownBadInputsRuleSet,
           priority: 1,
           overrideAction: { none: {} },
           statement: {
             managedRuleGroupStatement: {
               vendorName: "AWS",
-              name: "AWSManagedRulesKnownBadInputsRuleSet",
+              name: metricName.AWSManagedRulesKnownBadInputsRuleSet,
             },
           },
           visibilityConfig: {
             cloudWatchMetricsEnabled: true,
-            metricName: "AWSManagedRulesKnownBadInputsRuleSet",
+            metricName: metricName.AWSManagedRulesKnownBadInputsRuleSet,
             sampledRequestsEnabled: true,
           },
         },
@@ -274,18 +283,18 @@ export class FlexGlobalStack extends BaseStack {
           },
         },
         {
-          name: "AWSManagedRulesAmazonIpReputationList",
+          name: metricName.AWSManagedRulesAmazonIpReputationList,
           priority: 3,
           overrideAction: { none: {} },
           statement: {
             managedRuleGroupStatement: {
               vendorName: "AWS",
-              name: "AWSManagedRulesAmazonIpReputationList",
+              name: metricName.AWSManagedRulesAmazonIpReputationList,
             },
           },
           visibilityConfig: {
             cloudWatchMetricsEnabled: true,
-            metricName: "AWSManagedRulesAmazonIpReputationList",
+            metricName: metricName.AWSManagedRulesAmazonIpReputationList,
             sampledRequestsEnabled: true,
           },
         },
@@ -310,9 +319,11 @@ export class FlexGlobalStack extends BaseStack {
 
     new WafAlarms(this, "CloudFrontWafAlarms", {
       alarmNamePrefix: `${stage}-cloudfront-waf`,
+      webAclScope: "CLOUDFRONT",
+      webAclMetricName,
+      managedRuleMetricNames: Object.values(metricName),
       criticalAction,
       warningAction,
-      webAcl,
     });
 
     return { e2eBypassSecret, webAcl };

--- a/platform/infra/flex/src/stacks/platform.ts
+++ b/platform/infra/flex/src/stacks/platform.ts
@@ -388,6 +388,12 @@ export class FlexPlatformStack extends BaseStack {
       "Using AWS managed keys is fine in this case and lets us replicate cross region without issues",
     );
 
+    const webAclMetricName = "OriginVerifyWebAcl";
+    const metricName = {
+      AWSManagedRulesKnownBadInputsRuleSet:
+        "AWSManagedRulesKnownBadInputsRuleSet",
+    };
+
     const webAcl = new CfnWebACL(this, "ApiWebAcl", {
       scope: "REGIONAL",
       defaultAction: {
@@ -396,7 +402,7 @@ export class FlexPlatformStack extends BaseStack {
       visibilityConfig: {
         sampledRequestsEnabled: true,
         cloudWatchMetricsEnabled: true,
-        metricName: "OriginVerifyWebAcl",
+        metricName: webAclMetricName,
       },
       dataProtectionConfig: {
         dataProtections: [
@@ -413,10 +419,26 @@ export class FlexPlatformStack extends BaseStack {
       },
       rules: [
         {
-          name: "RequireOriginSecret",
+          name: metricName.AWSManagedRulesKnownBadInputsRuleSet,
           priority: 0,
+          overrideAction: { none: {} },
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: "AWS",
+              name: metricName.AWSManagedRulesKnownBadInputsRuleSet,
+            },
+          },
           visibilityConfig: {
-            cloudWatchMetricsEnabled: false,
+            cloudWatchMetricsEnabled: true,
+            metricName: metricName.AWSManagedRulesKnownBadInputsRuleSet,
+            sampledRequestsEnabled: true,
+          },
+        },
+        {
+          name: "RequireOriginSecret",
+          priority: 1,
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
             sampledRequestsEnabled: false,
             metricName: "RequireOriginSecret",
           },
@@ -434,24 +456,6 @@ export class FlexPlatformStack extends BaseStack {
             },
           },
         },
-        {
-          name: "AWSManagedRulesKnownBadInputsRuleSet",
-          priority: 1,
-          visibilityConfig: {
-            cloudWatchMetricsEnabled: false,
-            sampledRequestsEnabled: false,
-            metricName: "AWSManagedRulesKnownBadInputsRuleSet",
-          },
-          overrideAction: {
-            none: {},
-          },
-          statement: {
-            managedRuleGroupStatement: {
-              name: "AWSManagedRulesKnownBadInputsRuleSet",
-              vendorName: "AWS",
-            },
-          },
-        },
       ],
     });
 
@@ -460,11 +464,13 @@ export class FlexPlatformStack extends BaseStack {
       resourceArn: restApiStageArn,
     });
 
-    new WafAlarms(this, "ApiWafAlarms", {
-      alarmNamePrefix: `${stage}-waf`,
+    new WafAlarms(this, "WafApiAlarms", {
+      alarmNamePrefix: `${stage}-api-waf`,
+      webAclScope: "REGIONAL",
+      webAclMetricName,
+      managedRuleMetricNames: ["ALL"],
       criticalAction,
       warningAction,
-      webAcl,
     });
 
     return { originVerifySecret };


### PR DESCRIPTION
# Pull Request

## Description

Swapped to use `AnomalyDetectionAlarm`. Updated to support metrics without a region i.e the global cloudfront metrics don't include a region.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-324

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined