### PR TITLE
FLEX-000 feat(NOT-325): Removing unused properties (#413) - Revert

### DIFF
--- a/platform/domains/uns/gateway.config.ts
+++ b/platform/domains/uns/gateway.config.ts
@@ -15,6 +15,7 @@ export const { config, createHandler } = defineGateway({
       scope: "environment",
       config: z.object({
         apiKey: NonEmptyString,
+        apiUrl: NonEmptyString,
         privateApiUrl: NonEmptyString,
         region: NonEmptyString,
         roleArn: NonEmptyString,

--- a/platform/domains/uns/src/handlers/service-gateway.test.ts
+++ b/platform/domains/uns/src/handlers/service-gateway.test.ts
@@ -18,6 +18,7 @@ const TEST_SECRET_ARN =
   "arn:aws:secretsmanager:eu-west-2:123456789012:secret:uns-consumer";
 
 const TEST_CONSUMER_CONFIG: ConsumerConfig = {
+  apiUrl: "https://uns-remote.example.test",
   roleArn: "arn:aws:iam:123456789012:role/uns-consumer-role", // pragma: allowlist secret
   apiKey: `api123`, // pragma: allowlist secret
   privateApiUrl: "https://uns-remote-private.example.test",

--- a/platform/domains/uns/src/utils/getConsumerConfig.ts
+++ b/platform/domains/uns/src/utils/getConsumerConfig.ts
@@ -3,6 +3,7 @@ import { NonEmptyString } from "@flex/utils";
 import { z } from "zod";
 
 const consumerConfigSchema = z.object({
+  apiUrl: NonEmptyString,
   apiKey: NonEmptyString,
   roleArn: NonEmptyString,
   privateApiUrl: NonEmptyString,


### PR DESCRIPTION
This reverts commit 508766266be5b7e6be910e175e8ce1cf587d4261.

Reverting past PR as it's causing issues with E2E tests due to new consumer secrets within UNS domain

Will get back to this soon but just want to make sure flex integration and e2e tests remain unaffected