### PR TITLE
GOVUKAPP-3788 chore: enable unlinking dvla, expire linking id after 60 days UDP

### DIFF
--- a/domains/udp/src/handlers/v1/identity/[service]/delete.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.test.ts
@@ -96,4 +96,74 @@ describe("DELETE /v1/identity/:service", () => {
       expect(result.body).toBe("");
     },
   );
+
+  describe("Unlink tests when service is 'dvla'", () => {
+    const dvlaEndpoint = "/identity/dvla";
+
+    it("calls dvlaUnlinkUser integration, logs the result, and returns 204", async ({
+      http,
+      sdk,
+    }) => {
+      const dvlaResponse = { success: true };
+
+      http
+        .gateway("udp")
+        .get("/identity/dvla", {
+          headers: { "User-Id": userId },
+        })
+        .reply(200, { ...serviceIdentityLink, serviceName: "dvla" });
+
+      http
+        .gateway("udp")
+        .delete(`/identity/dvla/${serviceIdentityLink.serviceId}`)
+        .reply(204);
+
+      http
+        .domain("dvla")
+        .post(`/unlink/${serviceIdentityLink.serviceId}`)
+        .reply(200, dvlaResponse);
+
+      const result = await handler(
+        sdk.event.delete(dvlaEndpoint, {
+          userId,
+          params: { service: "dvla" },
+        }),
+        sdk.context(),
+      );
+
+      expect(result.statusCode).toBe(204);
+    });
+
+    it("still returns 204 even if dvlaUnlinkUser integration fails", async ({
+      http,
+      sdk,
+    }) => {
+      http
+        .gateway("udp")
+        .get("/identity/dvla", {
+          headers: { "User-Id": userId },
+        })
+        .reply(200, { ...serviceIdentityLink, serviceName: "dvla" });
+
+      http
+        .gateway("udp")
+        .delete(`/identity/dvla/${serviceIdentityLink.serviceId}`)
+        .reply(204);
+
+      http
+        .domain("dvla")
+        .post(`/unlink/${serviceIdentityLink.serviceId}`)
+        .reply(500, { message: "DVLA system error" });
+
+      const result = await handler(
+        sdk.event.delete(dvlaEndpoint, {
+          userId,
+          params: { service: "DVLA" },
+        }),
+        sdk.context(),
+      );
+
+      expect(result.statusCode).toBe(204);
+    });
+  });
 });

--- a/domains/udp/src/handlers/v1/identity/[service]/delete.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/delete.ts
@@ -8,7 +8,7 @@ import createHttpError from "http-errors";
 import status from "http-status";
 
 export const handler = route("DELETE /v1/identity/:service", async (ctx) => {
-  const { auth, pathParams } = ctx;
+  const { auth, pathParams, integrations, logger } = ctx;
   const service = pathParams.service.toLowerCase();
 
   // TODO: SDK auth alias
@@ -19,17 +19,19 @@ export const handler = route("DELETE /v1/identity/:service", async (ctx) => {
 
   await deleteServiceIdentity(identity.serviceName, identity.serviceId);
 
-  /**
-   * NOTE:
-   * - Commenting out for now as causing issues due to deleting the linking id
-   *   on DVLA side
-   */
-  // if (service === "dvla") {
-  //   await integrations.dvlaUnlinkUser({
-  //     body: {},
-  //     path: `/${identity.serviceId}`,
-  //   });
-  // }
+  if (service === "dvla") {
+    const result = await integrations.dvlaUnlinkUser({
+      body: {},
+      path: `/${identity.serviceId}`,
+    });
+
+    /**
+     * NOTE:
+     *  - Log response from DVLA but still unlink user regardless if successful
+     *    or not.
+     */
+    logger.info(JSON.stringify(result));
+  }
 
   return { status: status.NO_CONTENT };
 });

--- a/platform/domains/dvla/package.json
+++ b/platform/domains/dvla/package.json
@@ -21,6 +21,7 @@
     "@flex/utils": "workspace:*",
     "@middy/core": "7.7.0",
     "http-errors": "2.0.1",
+    "uuid": "14.0.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/platform/domains/dvla/src/client/index.ts
+++ b/platform/domains/dvla/src/client/index.ts
@@ -1,7 +1,7 @@
+import { logger } from "@flex/logging";
 import { ApiResult, typedFetch } from "@flex/sdk";
 import { createPublicFetch } from "@flex/service-gateway";
 import { v4 as uuidv4 } from "uuid";
-import { logger } from "@flex/logging";
 
 import { DVLA_REMOTE_ROUTES } from "../contract/route";
 import { JwkSet } from "../schemas/remote/wellKnownJwk";

--- a/platform/domains/dvla/src/client/index.ts
+++ b/platform/domains/dvla/src/client/index.ts
@@ -1,5 +1,7 @@
 import { ApiResult, typedFetch } from "@flex/sdk";
 import { createPublicFetch } from "@flex/service-gateway";
+import { v4 as uuidv4 } from "uuid";
+import { logger } from "@flex/logging";
 
 import { DVLA_REMOTE_ROUTES } from "../contract/route";
 import { JwkSet } from "../schemas/remote/wellKnownJwk";
@@ -15,9 +17,13 @@ let jwksCache: ApiResult<JwkSet> | null = null;
  */
 export function createDvlaRemoteClient(config: ConsumerConfig) {
   const fetcher = createPublicFetch({ baseUrl: config.apiUrl });
+  const correlationId = uuidv4();
+
+  logger.info(`DVLA Correlation ID: ${correlationId}`);
 
   const defaultHeaders = {
     Accept: "application/json",
+    "X-Correlation-Id": correlationId,
   };
 
   return {

--- a/platform/domains/udp/src/client/index.ts
+++ b/platform/domains/udp/src/client/index.ts
@@ -110,7 +110,6 @@ export function createUdpRemoteClient(config: ConsumerConfig) {
         identifier: string,
         body: CreateIdentityBodyRequest,
       ): Promise<ApiResult<void>> => {
-
         const SIXTY_DAYS_IN_SECONDS = 60 * 24 * 60 * 60; // 5,184,000
         const payload = {
           ...body,

--- a/platform/domains/udp/src/client/index.ts
+++ b/platform/domains/udp/src/client/index.ts
@@ -110,11 +110,18 @@ export function createUdpRemoteClient(config: ConsumerConfig) {
         identifier: string,
         body: CreateIdentityBodyRequest,
       ): Promise<ApiResult<void>> => {
+
+        const SIXTY_DAYS_IN_SECONDS = 60 * 24 * 60 * 60; // 5,184,000
+        const payload = {
+          ...body,
+          expiresAt: Math.floor(Date.now() / 1000) + SIXTY_DAYS_IN_SECONDS,
+        };
+
         const { request } = fetcher(
           `${UDP_REMOTE_ROUTES.identity}/${serviceName}/${identifier}`,
           {
             method: "POST",
-            body: JSON.stringify(body),
+            body: JSON.stringify(payload),
             headers: defaultHeaders,
           },
         );

--- a/platform/domains/udp/src/schemas/domain/identity.ts
+++ b/platform/domains/udp/src/schemas/domain/identity.ts
@@ -6,10 +6,7 @@ export const createIdentityRequestBodySchema = z.object({
   accessToken: NonEmptyString.optional(),
   refreshToken: NonEmptyString.optional(),
   idToken: NonEmptyString.optional(),
-  expiresAt: z
-    .number()
-    .int()
-    .optional(),
+  expiresAt: z.number().int().optional(),
 });
 
 export const createIdentityRequestSchema = z.object({

--- a/platform/domains/udp/src/schemas/domain/identity.ts
+++ b/platform/domains/udp/src/schemas/domain/identity.ts
@@ -6,6 +6,10 @@ export const createIdentityRequestBodySchema = z.object({
   accessToken: NonEmptyString.optional(),
   refreshToken: NonEmptyString.optional(),
   idToken: NonEmptyString.optional(),
+  expiresAt: z
+    .number()
+    .int()
+    .optional(),
 });
 
 export const createIdentityRequestSchema = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: 0.28.1
       eslint:
         specifier: 10.6.0
-        version: 10.6.0(jiti@2.7.0)
+        version: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
       nx:
         specifier: 23.0.1
         version: 23.0.1
@@ -442,7 +442,7 @@ importers:
         version: link:../config
       eslint:
         specifier: 10.6.0
-        version: 10.6.0(jiti@2.7.0)(supports-color@8.1.1)
+        version: 10.6.0(jiti@2.7.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -786,6 +786,9 @@ importers:
       http-errors:
         specifier: 2.0.1
         version: 2.0.1
+      uuid:
+        specifier: 14.0.1
+        version: 14.0.1
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -6910,6 +6913,10 @@ packages:
 
   uuid@11.1.1:
     resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
     hasBin: true
 
   uuid@9.0.1:
@@ -14244,6 +14251,8 @@ snapshots:
   uuid@10.0.0: {}
 
   uuid@11.1.1: {}
+
+  uuid@14.0.1: {}
 
   uuid@9.0.1:
     optional: true


### PR DESCRIPTION
# Pull Request

## Description

- Expire the linking ID after 60 days in UDP
- When a user unlinks tells DVLA that the user is no longer linked in the app with DVLA

**Related Issue:** https://govukverify.atlassian.net/browse/GOVUKAPP-3788

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
