### PR TITLE
FEAT-422 fix: main triggers zap workflow only

### DIFF
--- a/.github/workflows/zap.yml
+++ b/.github/workflows/zap.yml
@@ -5,6 +5,7 @@ on:
     workflows: [Continuous Deployment]
     types:
       - completed
+    branches: [main] # Only triggers from `main`
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
# Pull Request

## Description

- `zap.yml`: Only workflow to define `workflow_run`
- Only triggers ZAP scan on pushes to main, no trigger can run `zap.yml` from other actions

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-422

## Type of Change

Please check options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
