### PR TITLE
FLEX-416 chore: only allow dvla service to link with UDP

### DIFF
--- a/domains/udp/e2e/udp.test.ts
+++ b/domains/udp/e2e/udp.test.ts
@@ -170,14 +170,13 @@ describe.runIf(isDomainDeployed(udpConfig))("UDP domain", () => {
         expect(resultNotFound.status).toBe(404);
       });
     });
-  });
 
-  describe("/udp/v1/identity/:service", () => {
-    const endpoint = `/udp/v1/identity/${service}`;
+    describe("/udp/v1/identity/:service", () => {
+      const endpoint = `/udp/v1/identity/${service}`;
 
-    describe.runIf(udpCreateIdentityDeployed() && udpDeleteIdentityDeployed())(
-      "POST",
-      () => {
+      describe.runIf(
+        udpCreateIdentityDeployed() && udpDeleteIdentityDeployed(),
+      )("POST", () => {
         it("handles the service identity lifecycle (Link, Re-link, and Idempotency)", async ({
           cloudfront,
           withCleanIdentity,
@@ -212,8 +211,8 @@ describe.runIf(isDomainDeployed(udpConfig))("UDP domain", () => {
 
           expect(swapResult.status).toBe(201);
         });
-      },
-    );
+      });
+    });
   });
 
   describe("/udp/v1/users/me", () => {

--- a/domains/udp/e2e/udp.test.ts
+++ b/domains/udp/e2e/udp.test.ts
@@ -22,7 +22,11 @@ describe.runIf(isDomainDeployed(udpConfig))("UDP domain", () => {
   const serviceId = "test-service-id";
   const service = "test-service";
 
-  describe("/udp/v1/identity", () => {
+  /**
+   * Skipping identity endpoints for UDP for now as only works with DVLA
+   * and is quite awkward to replicate
+   */
+  describe.todo("/udp/v1/identity", () => {
     const listEndpoint = "/udp/v1/identity";
     const endpoint = `${listEndpoint}/${service}`;
 

--- a/domains/udp/src/handlers/v1/identity/[service]/post.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/post.test.ts
@@ -6,9 +6,7 @@ import {
   createServiceIdentityLink,
   secrets,
   serviceId,
-  serviceIdentityLink,
   serviceIdentityLinkRequest,
-  serviceName,
   userId,
 } from "@tests/fixtures";
 import * as jose from "jose";
@@ -155,9 +153,9 @@ const createMockDvlaJwe = async (
 };
 
 describe("POST /v1/identity/:service", () => {
-  const normalizedServiceName = serviceName.toLowerCase();
-  const endpoint = `/identity/${normalizedServiceName}`;
-  const standardHeaders = { "x-linking-token": serviceId };
+  const dvlaService = "dvla";
+  const targetDvlaEndpoint = `/identity/${dvlaService}`;
+  const jwksPath = "/well-known-jwks";
 
   interface MockCommand {
     args?: { CiphertextBlob?: Uint8Array };
@@ -192,79 +190,65 @@ describe("POST /v1/identity/:service", () => {
     });
   });
 
-  it("returns 201 when the service identity is successfully linked", async ({
+  it("returns 403 Forbidden when service is not DVLA", async ({ sdk }) => {
+    const jti = uuid;
+    const { accessToken } = await createMockSession(jti);
+
+    const result = await handler(
+      sdk.event.post("/identity/other-service", {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: "other-service" },
+        headers: {
+          "x-linking-token": serviceId,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
+
+    expect(result.statusCode).toBe(403);
+  });
+
+  it("returns 201 when the service identity is successfully linked for DVLA", async ({
     http,
     sdk,
   }) => {
     const jti = uuid;
-    const { accessToken } = await createMockSession(jti);
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
     http
       .gateway("udp")
-      .get(`/identity/${normalizedServiceName}`, {
+      .get(`/identity/${dvlaService}`, {
         headers: { "User-Id": userId },
       })
       .reply(404);
     http
       .gateway("udp")
-      .post(`/identity/${normalizedServiceName}/${serviceId}`)
+      .post(`/identity/${dvlaService}/${serviceId}`)
       .reply(201);
 
     const result = await handler(
-      sdk.event.post(endpoint, {
+      sdk.event.post(targetDvlaEndpoint, {
         userId,
         body: serviceIdentityLinkRequest,
-        params: { service: serviceName },
-        headers: { ...standardHeaders, Authorization: accessToken },
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": dvlaJweToken,
+          Authorization: accessToken,
+        },
       }),
       sdk.context({ secrets }),
     );
 
     expect(result.statusCode).toBe(201);
-    expect(result.body).toBe("");
+    expect(mockKmsSend).toHaveBeenCalledTimes(1);
   });
 
   describe("DVLA Integration Testing", () => {
-    const dvlaService = "dvla";
-    const targetDvlaEndpoint = `/identity/${dvlaService}`;
-    const jwksPath = "/well-known-jwks";
-
-    it("extracts serviceId securely from JWE payload and updates it when the service is DVLA", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
-
-      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
-
-      http
-        .gateway("udp")
-        .get(`/identity/${dvlaService}`, { headers: { "User-Id": userId } })
-        .reply(404);
-      http
-        .gateway("udp")
-        .post(`/identity/${dvlaService}/${serviceId}`)
-        .reply(201);
-
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": dvlaJweToken,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
-
-      expect(result.statusCode).toBe(201);
-      expect(mockKmsSend).toHaveBeenCalledTimes(1);
-    });
-
     it("returns 401 Unauthorized when the DVLA linking token has expired", async ({
       http,
       sdk,
@@ -295,7 +279,7 @@ describe("POST /v1/identity/:service", () => {
       expect(result.statusCode).toBe(401);
     });
 
-    it("returns 401 Unauthorized when token signature algorithm does not match the patched JWK parameters", async ({
+    it("returns 401 Unauthorized when token signature algorithm does not match JWK parameters", async ({
       http,
       sdk,
     }) => {
@@ -304,9 +288,7 @@ describe("POST /v1/identity/:service", () => {
       const invalidAlgJweToken = await createMockDvlaJwe(
         serviceId,
         sessionHash,
-        {
-          invalidAlg: true,
-        },
+        { invalidAlg: true },
       );
 
       http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
@@ -455,9 +437,7 @@ describe("POST /v1/identity/:service", () => {
       const tokenWithoutLinkingId = await createMockDvlaJwe(
         serviceId,
         sessionHash,
-        {
-          omitLinkingId: true,
-        },
+        { omitLinkingId: true },
       );
 
       http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
@@ -478,7 +458,7 @@ describe("POST /v1/identity/:service", () => {
       expect(result.statusCode).toBe(401);
     });
 
-    it("returns 401 when the calculated session has doesn't match the provided one", async ({
+    it("returns 401 when the calculated session hash doesn't match the provided one", async ({
       http,
       sdk,
     }) => {
@@ -513,21 +493,32 @@ describe("POST /v1/identity/:service", () => {
     sdk,
   }) => {
     const jti = uuid;
-    const { accessToken } = await createMockSession(jti);
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
+
+    const dvlaLink = createServiceIdentityLink({
+      serviceId,
+      serviceName: dvlaService,
+    });
 
     http
       .gateway("udp")
-      .get(`/identity/${normalizedServiceName}`, {
+      .get(`/identity/${dvlaService}`, {
         headers: { "User-Id": userId },
       })
-      .reply(200, serviceIdentityLink);
+      .reply(200, dvlaLink);
 
     const result = await handler(
-      sdk.event.post(endpoint, {
+      sdk.event.post(targetDvlaEndpoint, {
         userId,
         body: serviceIdentityLinkRequest,
-        params: { service: serviceName },
-        headers: { ...standardHeaders, Authorization: accessToken },
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": dvlaJweToken,
+          Authorization: accessToken,
+        },
       }),
       sdk.context({ secrets }),
     );
@@ -543,34 +534,39 @@ describe("POST /v1/identity/:service", () => {
     const oldServiceId = createServiceId("test-old-service-id");
     const existingServiceIdentity = createServiceIdentityLink({
       serviceId: oldServiceId,
+      serviceName: dvlaService,
     });
-    const normalizedExistingService =
-      existingServiceIdentity.serviceName.toLowerCase();
 
     const jti = uuid;
-    const { accessToken } = await createMockSession(jti);
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
     http
       .gateway("udp")
-      .get(`/identity/${normalizedServiceName}`, {
+      .get(`/identity/${dvlaService}`, {
         headers: { "User-Id": userId },
       })
       .reply(200, existingServiceIdentity);
     http
       .gateway("udp")
-      .delete(`/identity/${normalizedExistingService}/${oldServiceId}`)
+      .delete(`/identity/${dvlaService}/${oldServiceId}`)
       .reply(204);
     http
       .gateway("udp")
-      .post(`/identity/${normalizedServiceName}/${serviceId}`)
+      .post(`/identity/${dvlaService}/${serviceId}`)
       .reply(201);
 
     const result = await handler(
-      sdk.event.post(endpoint, {
+      sdk.event.post(targetDvlaEndpoint, {
         userId,
         body: serviceIdentityLinkRequest,
-        params: { service: serviceName },
-        headers: { ...standardHeaders, Authorization: accessToken },
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": dvlaJweToken,
+          Authorization: accessToken,
+        },
       }),
       sdk.context({ secrets }),
     );
@@ -583,21 +579,27 @@ describe("POST /v1/identity/:service", () => {
     "returns $expected when the UDP get service identity link integration $reason",
     async ({ upstream, expected }, { http, sdk }) => {
       const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
+      const { accessToken, sessionHash } = await createMockSession(jti);
+      const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+
+      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
       http
         .gateway("udp")
-        .get(`/identity/${normalizedServiceName}`, {
+        .get(`/identity/${dvlaService}`, {
           headers: { "User-Id": userId },
         })
         .reply(upstream);
 
       const result = await handler(
-        sdk.event.post(endpoint, {
+        sdk.event.post(targetDvlaEndpoint, {
           userId,
           body: serviceIdentityLinkRequest,
-          params: { service: serviceName },
-          headers: { ...standardHeaders, Authorization: accessToken },
+          params: { service: dvlaService },
+          headers: {
+            "x-linking-token": dvlaJweToken,
+            Authorization: accessToken,
+          },
         }),
         sdk.context({ secrets }),
       );
@@ -614,33 +616,38 @@ describe("POST /v1/identity/:service", () => {
     "returns $expected when the UDP delete service identity link integration $reason",
     async ({ upstream, expected }, { http, sdk }) => {
       const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
+      const { accessToken, sessionHash } = await createMockSession(jti);
+      const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
 
       const oldServiceId = createServiceId("test-old-service-id");
       const existingServiceIdentity = createServiceIdentityLink({
         serviceId: oldServiceId,
+        serviceName: dvlaService,
       });
-      const normalizedExistingService =
-        existingServiceIdentity.serviceName.toLowerCase();
+
+      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
       http
         .gateway("udp")
-        .get(`/identity/${normalizedServiceName}`, {
+        .get(`/identity/${dvlaService}`, {
           headers: { "User-Id": userId },
         })
         .reply(200, existingServiceIdentity);
 
       http
         .gateway("udp")
-        .delete(`/identity/${normalizedExistingService}/${oldServiceId}`)
+        .delete(`/identity/${dvlaService}/${oldServiceId}`)
         .reply(upstream);
 
       const result = await handler(
-        sdk.event.post(endpoint, {
+        sdk.event.post(targetDvlaEndpoint, {
           userId,
           body: serviceIdentityLinkRequest,
-          params: { service: serviceName },
-          headers: { ...standardHeaders, Authorization: accessToken },
+          params: { service: dvlaService },
+          headers: {
+            "x-linking-token": dvlaJweToken,
+            Authorization: accessToken,
+          },
         }),
         sdk.context({ secrets }),
       );
@@ -654,26 +661,32 @@ describe("POST /v1/identity/:service", () => {
     "returns $expected when the UDP create service identity integration $reason",
     async ({ upstream, expected }, { http, sdk }) => {
       const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
+      const { accessToken, sessionHash } = await createMockSession(jti);
+      const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+
+      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
       http
         .gateway("udp")
-        .get(`/identity/${normalizedServiceName}`, {
+        .get(`/identity/${dvlaService}`, {
           headers: { "User-Id": userId },
         })
         .reply(404);
 
       http
         .gateway("udp")
-        .post(`/identity/${normalizedServiceName}/${serviceId}`)
+        .post(`/identity/${dvlaService}/${serviceId}`)
         .reply(upstream);
 
       const result = await handler(
-        sdk.event.post(endpoint, {
+        sdk.event.post(targetDvlaEndpoint, {
           userId,
           body: serviceIdentityLinkRequest,
-          params: { service: serviceName },
-          headers: { ...standardHeaders, Authorization: accessToken },
+          params: { service: dvlaService },
+          headers: {
+            "x-linking-token": dvlaJweToken,
+            Authorization: accessToken,
+          },
         }),
         sdk.context({ secrets }),
       );

--- a/domains/udp/src/handlers/v1/identity/[service]/post.test.ts
+++ b/domains/udp/src/handlers/v1/identity/[service]/post.test.ts
@@ -248,244 +248,240 @@ describe("POST /v1/identity/:service", () => {
     expect(mockKmsSend).toHaveBeenCalledTimes(1);
   });
 
-  describe("DVLA Integration Testing", () => {
-    it("returns 401 Unauthorized when the DVLA linking token has expired", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const expiredDvlaJweToken = await createMockDvlaJwe(
-        serviceId,
-        sessionHash,
-        { isExpired: true },
-      );
+  it("returns 401 Unauthorized when the DVLA linking token has expired", async ({
+    http,
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const expiredDvlaJweToken = await createMockDvlaJwe(
+      serviceId,
+      sessionHash,
+      { isExpired: true },
+    );
 
-      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": expiredDvlaJweToken,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": expiredDvlaJweToken,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      expect(result.statusCode).toBe(401);
+    expect(result.statusCode).toBe(401);
+  });
+
+  it("returns 401 Unauthorized when token signature algorithm does not match JWK parameters", async ({
+    http,
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const invalidAlgJweToken = await createMockDvlaJwe(serviceId, sessionHash, {
+      invalidAlg: true,
     });
 
-    it("returns 401 Unauthorized when token signature algorithm does not match JWK parameters", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const invalidAlgJweToken = await createMockDvlaJwe(
-        serviceId,
-        sessionHash,
-        { invalidAlg: true },
-      );
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
-      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": invalidAlgJweToken,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": invalidAlgJweToken,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(401);
+  });
 
-      expect(result.statusCode).toBe(401);
-    });
+  it("returns 502 Bad Gateway when fetching the DVLA well-known JWK endpoint fails", async ({
+    http,
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
 
-    it("returns 502 Bad Gateway when fetching the DVLA well-known JWK endpoint fails", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const dvlaJweToken = await createMockDvlaJwe(serviceId, sessionHash);
+    http.gateway("dvla").get(jwksPath).reply(500);
 
-      http.gateway("dvla").get(jwksPath).reply(500);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": dvlaJweToken,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": dvlaJweToken,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(502);
+  });
 
-      expect(result.statusCode).toBe(502);
-    });
+  it("returns 400 Bad Request when the JWE token format is invalid (not 5 parts)", async ({
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken } = await createMockSession(jti);
 
-    it("returns 400 Bad Request when the JWE token format is invalid (not 5 parts)", async ({
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": "eyJhbGciOi.InvalidToken",
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": "eyJhbGciOi.InvalidToken",
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(400);
+  });
 
-      expect(result.statusCode).toBe(400);
-    });
+  it("returns 400 Bad Request when essential JWE token blocks are empty", async ({
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken } = await createMockSession(jti);
 
-    it("returns 400 Bad Request when essential JWE token blocks are empty", async ({
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": "part1.part2..part4.part5",
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": "part1.part2..part4.part5",
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(400);
+  });
 
-      expect(result.statusCode).toBe(400);
-    });
+  it("returns 500 Internal Server Error when KMS fails to return a decrypted Plaintext CEK", async ({
+    sdk,
+  }) => {
+    mockKmsSend.mockResolvedValueOnce({ Plaintext: undefined });
 
-    it("returns 500 Internal Server Error when KMS fails to return a decrypted Plaintext CEK", async ({
-      sdk,
-    }) => {
-      mockKmsSend.mockResolvedValueOnce({ Plaintext: undefined });
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const validJwe = await createMockDvlaJwe(serviceId, sessionHash);
 
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const validJwe = await createMockDvlaJwe(serviceId, sessionHash);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: { "x-linking-token": validJwe, Authorization: accessToken },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: { "x-linking-token": validJwe, Authorization: accessToken },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(500);
+  });
 
-      expect(result.statusCode).toBe(500);
-    });
+  it("returns 400 Bad Request when internal AES-GCM decryption fails (tampered payload)", async ({
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const validJwe = await createMockDvlaJwe(serviceId, sessionHash);
 
-    it("returns 400 Bad Request when internal AES-GCM decryption fails (tampered payload)", async ({
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const validJwe = await createMockDvlaJwe(serviceId, sessionHash);
+    const parts = validJwe.split(".");
+    parts[3] = "tampered_ciphertext_to_break_decryption_completely";
+    const tamperedJwe = parts.join(".");
 
-      const parts = validJwe.split(".");
-      parts[3] = "tampered_ciphertext_to_break_decryption_completely";
-      const tamperedJwe = parts.join(".");
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": tamperedJwe,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": tamperedJwe,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(400);
+  });
 
-      expect(result.statusCode).toBe(400);
-    });
+  it("returns 401 when the decrypted JWT is missing the linking_id claim", async ({
+    http,
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken, sessionHash } = await createMockSession(jti);
+    const tokenWithoutLinkingId = await createMockDvlaJwe(
+      serviceId,
+      sessionHash,
+      { omitLinkingId: true },
+    );
 
-    it("returns 401 when the decrypted JWT is missing the linking_id claim", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken, sessionHash } = await createMockSession(jti);
-      const tokenWithoutLinkingId = await createMockDvlaJwe(
-        serviceId,
-        sessionHash,
-        { omitLinkingId: true },
-      );
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
-      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": tokenWithoutLinkingId,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": tokenWithoutLinkingId,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
+    expect(result.statusCode).toBe(401);
+  });
 
-      expect(result.statusCode).toBe(401);
-    });
+  it("returns 401 when the calculated session hash doesn't match the provided one", async ({
+    http,
+    sdk,
+  }) => {
+    const jti = uuid;
+    const { accessToken } = await createMockSession(jti);
+    const tokenWithMismatchedHash = await createMockDvlaJwe(
+      serviceId,
+      "mismatched-hash",
+    );
 
-    it("returns 401 when the calculated session hash doesn't match the provided one", async ({
-      http,
-      sdk,
-    }) => {
-      const jti = uuid;
-      const { accessToken } = await createMockSession(jti);
-      const tokenWithMismatchedHash = await createMockDvlaJwe(
-        serviceId,
-        "mismatched-hash",
-      );
+    http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
 
-      http.gateway("dvla").get(jwksPath).reply(200, mockJwkSetResponse);
+    const result = await handler(
+      sdk.event.post(targetDvlaEndpoint, {
+        userId,
+        body: serviceIdentityLinkRequest,
+        params: { service: dvlaService },
+        headers: {
+          "x-linking-token": tokenWithMismatchedHash,
+          Authorization: accessToken,
+        },
+      }),
+      sdk.context({ secrets }),
+    );
 
-      const result = await handler(
-        sdk.event.post(targetDvlaEndpoint, {
-          userId,
-          body: serviceIdentityLinkRequest,
-          params: { service: dvlaService },
-          headers: {
-            "x-linking-token": tokenWithMismatchedHash,
-            Authorization: accessToken,
-          },
-        }),
-        sdk.context({ secrets }),
-      );
-
-      expect(result.statusCode).toBe(401);
-    });
+    expect(result.statusCode).toBe(401);
   });
 
   it("returns 204 when the service identity is already linked with the same ID", async ({

--- a/domains/udp/src/services/linkingId.ts
+++ b/domains/udp/src/services/linkingId.ts
@@ -181,31 +181,29 @@ export async function extractServiceId(
   accessToken: string,
   ctx: PostRouteContext,
 ): Promise<string | null> {
-  if (service.toLowerCase() === "dvla") {
-    const decryptedSignedJwt = await decryptJweToken(linkingToken, ctx);
+  if (service.toLowerCase() !== "dvla") throw new createHttpError.Forbidden();
 
-    ctx.logger.info("Fetching JWKS from DVLA integration...");
-    const result = await ctx.integrations.dvlaGetWellKnownJwk({});
+  const decryptedSignedJwt = await decryptJweToken(linkingToken, ctx);
 
-    if (!result.ok) {
-      ctx.logger.error("Failed to fetch DVLA well-known JWKs", {
-        error: result.error,
-      });
-      throw new createHttpError.BadGateway();
-    }
+  ctx.logger.info("Fetching JWKS from DVLA integration...");
+  const result = await ctx.integrations.dvlaGetWellKnownJwk({});
 
-    const payload = await verifyJwtAndExtractPayload(
-      decryptedSignedJwt,
-      result.data,
-      ctx,
-    );
-
-    if (payload === null || !payload.linking_id || !payload.session) {
-      return null;
-    }
-    verifySessionHash(payload.session, accessToken, ctx);
-    return payload.linking_id;
+  if (!result.ok) {
+    ctx.logger.error("Failed to fetch DVLA well-known JWKs", {
+      error: result.error,
+    });
+    throw new createHttpError.BadGateway();
   }
 
-  return linkingToken;
+  const payload = await verifyJwtAndExtractPayload(
+    decryptedSignedJwt,
+    result.data,
+    ctx,
+  );
+
+  if (payload === null || !payload.linking_id || !payload.session) {
+    return null;
+  }
+  verifySessionHash(payload.session, accessToken, ctx);
+  return payload.linking_id;
 }


### PR DESCRIPTION
# Pull Request

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Only allow DVLA to link via flex through the UDP service

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-416

## Type of Change

Please check options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
