### PR TITLE
FLEX-480 fix: destroy ephemeral OpenAPI-specs bucket on teardown

### DIFF
--- a/platform/infra/flex/src/constructs/s3/AccessLogBucket.ts
+++ b/platform/infra/flex/src/constructs/s3/AccessLogBucket.ts
@@ -1,4 +1,5 @@
-import { Duration } from "aws-cdk-lib";
+import { getEnvConfig } from "@flex/utils";
+import { Duration, RemovalPolicy } from "aws-cdk-lib";
 import {
   BlockPublicAccess,
   Bucket,
@@ -9,6 +10,8 @@ import {
 import { Construct } from "constructs";
 
 import { applyCheckovSkip } from "../../utils/applyCheckovSkip";
+
+const { persistent } = getEnvConfig();
 
 export class AccessLogBucket extends Construct {
   public readonly bucket: Bucket;
@@ -25,11 +28,12 @@ export class AccessLogBucket extends Construct {
       objectOwnership: ObjectOwnership.OBJECT_WRITER,
       accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
       versioned: true,
-      objectLockEnabled: true,
-      objectLockDefaultRetention: {
-        mode: ObjectLockMode.GOVERNANCE,
-        duration: retention,
-      },
+      objectLockEnabled: persistent,
+      objectLockDefaultRetention: persistent
+        ? { mode: ObjectLockMode.GOVERNANCE, duration: retention }
+        : undefined,
+      removalPolicy: persistent ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+      autoDeleteObjects: !persistent,
       lifecycleRules: [
         {
           id: "expireLogs",

--- a/platform/infra/flex/src/constructs/s3/AccessLogBucket.ts
+++ b/platform/infra/flex/src/constructs/s3/AccessLogBucket.ts
@@ -1,5 +1,4 @@
-import { getEnvConfig } from "@flex/utils";
-import { Duration, RemovalPolicy } from "aws-cdk-lib";
+import { Duration } from "aws-cdk-lib";
 import {
   BlockPublicAccess,
   Bucket,
@@ -10,8 +9,6 @@ import {
 import { Construct } from "constructs";
 
 import { applyCheckovSkip } from "../../utils/applyCheckovSkip";
-
-const { persistent } = getEnvConfig();
 
 export class AccessLogBucket extends Construct {
   public readonly bucket: Bucket;
@@ -28,12 +25,11 @@ export class AccessLogBucket extends Construct {
       objectOwnership: ObjectOwnership.OBJECT_WRITER,
       accessControl: BucketAccessControl.LOG_DELIVERY_WRITE,
       versioned: true,
-      objectLockEnabled: persistent,
-      objectLockDefaultRetention: persistent
-        ? { mode: ObjectLockMode.GOVERNANCE, duration: retention }
-        : undefined,
-      removalPolicy: persistent ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
-      autoDeleteObjects: !persistent,
+      objectLockEnabled: true,
+      objectLockDefaultRetention: {
+        mode: ObjectLockMode.GOVERNANCE,
+        duration: retention,
+      },
       lifecycleRules: [
         {
           id: "expireLogs",

--- a/platform/infra/flex/src/stacks/global.ts
+++ b/platform/infra/flex/src/stacks/global.ts
@@ -523,7 +523,8 @@ export class FlexGlobalStack extends BaseStack {
       bucketName: `flex-${stage}-openapi-specs`,
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       encryption: BucketEncryption.S3_MANAGED,
-      removalPolicy: RemovalPolicy.RETAIN,
+      removalPolicy: persistent ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+      autoDeleteObjects: !persistent,
       versioned: true,
       lifecycleRules: [
         {

--- a/platform/infra/flex/src/stacks/macie.ts
+++ b/platform/infra/flex/src/stacks/macie.ts
@@ -155,6 +155,8 @@ export class FlexMacieStack extends BaseStack {
           jobId: new PhysicalResourceIdReference(),
           jobStatus: "CANCELLED",
         },
+        ignoreErrorCodesMatching:
+          "ValidationException|ResourceNotFoundException|ConflictException",
       },
       policy: AwsCustomResourcePolicy.fromStatements([
         new PolicyStatement({


### PR DESCRIPTION
The OpenAPI-specs bucket used a fixed name with RemovalPolicy.RETAIN, so a torn down ephemeral stack left the bucket behind and the next deploy of that stage failed with 'bucket already exists'. Ephemeral/dev stages now use RemovalPolicy.DESTROY with autoDeleteObjects; persistent envs keep RETAIN.

# Pull Request

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

**Related Issue:** https://gdsgovukagents.atlassian.net/browse/FLEX-480

## Type of Change

Please check options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (code change that does not add functionality or fix a bug)
- [ ] Code cleanup (formatting, renaming)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please explain)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so others can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing (include instructions below)

## Checklist

- [ ] I have run the pre-commit
- [ ] I have run all necessary tests
- [ ] I have updated/added all necessary tests
- [ ] I have added or updated documentation
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have refactored my code to be more readable, maintainable and removed duplications.
- [ ] I have added guards around invalid inputs and edge cases such as nulls and undefined

## Screenshots (if applicable)

_Please add screenshots or videos to help explain your changes._

## Additional Notes

_Anything else you want to mention for reviewers?_
